### PR TITLE
Add ID containers for shader and program; add shader and program tests

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -122,4 +122,8 @@ void Program::setFloat(std::string name, float value) const {
   glUniform1f(p_id->findUniformLocation(name), value);
 }
 
+void Program::setVec2(std::string name, float x, float y) const {
+  glUniform2f(p_id->findUniformLocation(name), x, y);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -10,6 +10,7 @@
 #include "program.hpp"
 
 // C++ Standard Library
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
 
@@ -29,7 +30,7 @@ auto check_compilation_errors(unsigned int program_id) {
   if (glGetProgramiv(program_id, GL_LINK_STATUS, &success);
       success == GL_FALSE) {
     int info_length{0};
-    glGetShaderInfoLog(program_id, buffer_size, &info_length, buffer);
+    glGetProgramInfoLog(program_id, buffer_size, &info_length, buffer);
     std::ostringstream oss;
     oss << "Error compiling shader program " << program_id << ": "
         << std::string_view(buffer, info_length);

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -114,4 +114,8 @@ void Program::setBool(std::string name, bool value) const {
   glUniform1i(p_id->findUniformLocation(name), (int)value);
 }
 
+void Program::setInt(std::string name, int value) const {
+  glUniform1i(p_id->findUniformLocation(name), value);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -64,7 +64,7 @@ struct Program::IDContainer {
   ~IDContainer() noexcept { glDeleteProgram(m_id); }
 };
 
-Program::Program(std::vector<nzl::Shader>& shaders)
+Program::Program(std::vector<nzl::Shader> shaders)
     : m_shaders{shaders},
       p_id{std::make_shared<IDContainer>(create_program())} {}
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -126,4 +126,9 @@ void Program::setVec2(std::string name, float x, float y) const {
   glUniform2f(p_id->findUniformLocation(name), x, y);
 }
 
+void Program::setVec3(const std::string& name, float x, float y,
+                      float z) const {
+  glUniform3f(p_id->findUniformLocation(name), x, y, z);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -110,4 +110,8 @@ unsigned int Program::id() const noexcept { return p_id->m_id; }
 
 void Program::use() const noexcept { glUseProgram(p_id->m_id); }
 
+void Program::setBool(std::string name, bool value) const {
+  glUniform1i(p_id->findUniformLocation(name), (int)value);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -55,7 +55,7 @@ auto create_program() {
 
 namespace nzl {
 
-Program::Program(std::vector<nzl::Shader> shaders)
+Program::Program(std::vector<nzl::Shader>& shaders)
     : m_shaders{shaders}, m_id{create_program()} {}
 
 Program::~Program() noexcept { glDeleteProgram(m_id); }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -118,4 +118,8 @@ void Program::setInt(std::string name, int value) const {
   glUniform1i(p_id->findUniformLocation(name), value);
 }
 
+void Program::setFloat(std::string name, float value) const {
+  glUniform1f(p_id->findUniformLocation(name), value);
+}
+
 }  // namespace nzl

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -20,7 +20,7 @@ class Program {
  public:
   /// @brief Create a Program from the given @link Shader Shaders@endlink.
   /// @param shaders Shaders to be used to create this Program.
-  Program(std::vector<nzl::Shader> shaders);
+  Program(std::vector<nzl::Shader>& shaders);
 
   /// @brief Destroy this Program.
   ~Program() noexcept;
@@ -36,7 +36,7 @@ class Program {
   void operator=(const Program&) = delete;
 
  private:
-  const std::vector<nzl::Shader> m_shaders;
+  const std::vector<nzl::Shader>& m_shaders;
   const unsigned int m_id;
 };
 

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -32,6 +32,9 @@ class Program {
   /// @brief Return an identifier associated with this Program.
   unsigned int id() const noexcept;
 
+  Program(const Program&) = delete;
+  void operator=(const Program&) = delete;
+
  private:
   const std::vector<nzl::Shader> m_shaders;
   const unsigned int m_id;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -30,6 +30,9 @@ class Program {
   /// @brief Return an identifier associated with this Program.
   unsigned int id() const noexcept;
 
+  /// @brief Calls glUseProgram() with this program's id
+  void use() const noexcept;
+
  private:
   struct IDContainer;
   std::shared_ptr<IDContainer> p_id{nullptr};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -58,6 +58,14 @@ class Program {
   /// @param y Second value of the vec2 to be set
   void setVec2(std::string name, float x, float y) const;
 
+  /// @brief Sets a vec3 uniform within the shader
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param x First value of the vec3 to be set
+  /// @param y Second value of the vec3 to be set
+  /// @param z Thirds value of the vec4 to be set
+  void setVec3(const std::string& name, float x, float y, float z) const;
+
   struct IDContainer;
   std::shared_ptr<IDContainer> p_id{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -21,7 +21,7 @@ class Program {
  public:
   /// @brief Create a Program from the given @link Shader Shaders@endlink.
   /// @param shaders Shaders to be used to create this Program.
-  Program(std::vector<nzl::Shader>& shaders);
+  Program(std::vector<nzl::Shader> shaders);
 
   /// @brief Links and compiles this Program.
   /// @throws std::runtime_error on compilation failure.
@@ -33,7 +33,7 @@ class Program {
  private:
   struct IDContainer;
   std::shared_ptr<IDContainer> p_id{nullptr};
-  const std::vector<nzl::Shader>& m_shaders;
+  std::vector<nzl::Shader> m_shaders;
 };
 
 }  // namespace nzl

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -39,6 +39,12 @@ class Program {
   /// @param value Boolean value to be set
   void setBool(std::string name, bool value) const;
 
+  /// @brief Sets a int uniform within the shader
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Integer value to be set
+  void setInt(std::string name, int value) const;
+
  private:
   struct IDContainer;
   std::shared_ptr<IDContainer> p_id{nullptr};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 // C++ Standard Library
+#include <memory>
 #include <vector>
 
 // mxd Library
@@ -22,9 +23,6 @@ class Program {
   /// @param shaders Shaders to be used to create this Program.
   Program(std::vector<nzl::Shader>& shaders);
 
-  /// @brief Destroy this Program.
-  ~Program() noexcept;
-
   /// @brief Links and compiles this Program.
   /// @throws std::runtime_error on compilation failure.
   void compile();
@@ -32,12 +30,10 @@ class Program {
   /// @brief Return an identifier associated with this Program.
   unsigned int id() const noexcept;
 
-  Program(const Program&) = delete;
-  void operator=(const Program&) = delete;
-
  private:
+  struct IDContainer;
+  std::shared_ptr<IDContainer> p_id{nullptr};
   const std::vector<nzl::Shader>& m_shaders;
-  const unsigned int m_id;
 };
 
 }  // namespace nzl

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -33,6 +33,12 @@ class Program {
   /// @brief Calls glUseProgram() with this program's id
   void use() const noexcept;
 
+  /// @brief Sets a boolean uniform within the shader
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Boolean value to be set
+  void setBool(std::string name, bool value) const;
+
  private:
   struct IDContainer;
   std::shared_ptr<IDContainer> p_id{nullptr};

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -51,7 +51,13 @@ class Program {
   /// @param value Float value to be set
   void setFloat(std::string name, float value) const;
 
- private:
+  /// @brief Sets a vec2 uniform within the shader
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param x First value of the vec2 to be set
+  /// @param y Second value of the vec2 to be set
+  void setVec2(std::string name, float x, float y) const;
+
   struct IDContainer;
   std::shared_ptr<IDContainer> p_id{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -45,6 +45,12 @@ class Program {
   /// @param value Integer value to be set
   void setInt(std::string name, int value) const;
 
+  /// @brief Sets a float uniform within the shader
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Float value to be set
+  void setFloat(std::string name, float value) const;
+
  private:
   struct IDContainer;
   std::shared_ptr<IDContainer> p_id{nullptr};

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -10,11 +10,88 @@
 #include "program.hpp"
 
 // C++ Standard Library
+#include <vector>
 
 // mxd Library
+#include "mxd.hpp"
+#include "shader.hpp"
+#include "window.hpp"
 
 // Google Test Framework
 #include <gtest/gtest.h>
+
+TEST(Program, ParameterAccessAndCompilation) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  std::string vSource =
+      "#version 330\n"
+      "layout (location = 0) in vec3 aPos;\n"
+      "out vec4 vertexColor;\n"
+      "void main() {\n"
+      "gl_Position = vec4(aPos, 1.0);\n"
+      "vertexColor = vec4(0.5,0.0,0.0,1.0);\n}";
+
+  std::string fSource =
+      "#version 330\n"
+      "out vec4 FragColor;\n"
+      ""
+      "in vec4 vertexColor;\n"
+      ""
+      "void main(){\n"
+      "FragColor = vertexColor;}";
+
+  std::vector<nzl::Shader> shaders;
+
+  nzl::Shader shader1(nzl::Shader::Stage::Vertex, vSource);
+  shaders.push_back(shader1);
+  shaders.back().compile();
+  nzl::Shader shader2(nzl::Shader::Stage::Fragment, fSource);
+  shaders.push_back(shader2);
+  shaders.back().compile();
+
+  ASSERT_NO_THROW(nzl::Program program(shaders); program.compile(););
+
+  nzl::Program program(shaders);
+  EXPECT_NE(program.id(), 0u);
+
+  nzl::terminate();
+}
+
+TEST(Program, CopyConstructor) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  std::vector<nzl::Shader> shaders;
+
+  nzl::Program program1(shaders);
+  nzl::Program program2 = program1;
+  EXPECT_EQ(program1.id(), program2.id());
+
+  nzl::terminate();
+}
+
+TEST(Program, CopyOperator) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  std::vector<nzl::Shader> shaders;
+
+  nzl::Program program1(shaders);
+
+  nzl::Program program3(shaders);
+  EXPECT_NE(program1.id(), program3.id());
+  program3 = program1;
+  EXPECT_EQ(program3.id(), program1.id());
+
+  nzl::terminate();
+}
 
 TEST(Program, Failing) {
   ASSERT_TRUE(false) << "You must add unit tests for program.hpp";

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -158,6 +158,29 @@ TEST(Program, BoolUniform) {
   nzl::terminate();
 }
 
+TEST(Program, IntUniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{createUniformTestProgram()};
+
+  std::string name = "testInt";
+
+  program.use();
+  ASSERT_NO_THROW(program.setInt(name, 687););
+
+  int value = -1000;
+
+  glGetUniformiv(program.id(), glGetUniformLocation(program.id(), name.c_str()),
+                 &value);
+
+  EXPECT_EQ(value, 687);
+
+  nzl::terminate();
+}
+
 TEST(Program, Failing) {
   ASSERT_TRUE(false) << "You must add unit tests for program.hpp";
 }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -30,10 +30,12 @@ nzl::Program createUniformTestProgram() {
       "#version 330\n"
       "layout (location = 0) in vec3 aPos;\n"
       "out vec4 vertexColor;\n"
-      "uniform float testFloat;"
-      "uniform vec2 testVec2;"
+      "uniform float testFloat;\n"
+      "uniform vec2 testVec2;\n"
+      "uniform vec3 testVec3;\n"
       "void main() {\n"
       "vec3 pos = aPos;\n"
+      "pos*=testVec3;\n"
       "pos.xy+=testVec2;\n"
       "gl_Position = vec4(pos, 1.0*testFloat);\n"
       "vertexColor = vec4(0.5,0.0,0.0,1.0);\n}";
@@ -232,6 +234,36 @@ TEST(Program, 2FloatUniform) {
 
   EXPECT_FLOAT_EQ(ret[0], val1);
   EXPECT_FLOAT_EQ(ret[1], val2);
+
+  nzl::terminate();
+}
+
+TEST(Program, 3FloatUniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{createUniformTestProgram()};
+
+  std::string name = "testVec3";
+
+  float val1 = 523.1234f;
+  float val2 = 773.4321f;
+  float val3 = 123.65656f;
+
+  program.use();
+  ASSERT_NO_THROW(program.setVec3(name, val1, val2, val3););
+
+  float ret[3];
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  3 * sizeof(float), &ret[0]);
+
+  EXPECT_FLOAT_EQ(ret[0], val1);
+  EXPECT_FLOAT_EQ(ret[1], val2);
+  EXPECT_FLOAT_EQ(ret[2], val3);
 
   nzl::terminate();
 }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -31,8 +31,11 @@ nzl::Program createUniformTestProgram() {
       "layout (location = 0) in vec3 aPos;\n"
       "out vec4 vertexColor;\n"
       "uniform float testFloat;"
+      "uniform vec2 testVec2;"
       "void main() {\n"
-      "gl_Position = vec4(aPos, 1.0*testFloat);\n"
+      "vec3 pos = aPos;\n"
+      "pos.xy+=testVec2;\n"
+      "gl_Position = vec4(pos, 1.0*testFloat);\n"
       "vertexColor = vec4(0.5,0.0,0.0,1.0);\n}";
 
   std::string fSource =
@@ -201,6 +204,34 @@ TEST(Program, FloatUniform) {
                  &value);
 
   EXPECT_FLOAT_EQ(value, 687.34f);
+
+  nzl::terminate();
+}
+
+TEST(Program, 2FloatUniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{createUniformTestProgram()};
+
+  std::string name = "testVec2";
+
+  float val1 = 523.1234f;
+  float val2 = 773.4321f;
+
+  program.use();
+  ASSERT_NO_THROW(program.setVec2(name, val1, val2););
+
+  float ret[2];
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  2 * sizeof(float), &ret[0]);
+
+  EXPECT_FLOAT_EQ(ret[0], val1);
+  EXPECT_FLOAT_EQ(ret[1], val2);
 
   nzl::terminate();
 }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -30,8 +30,9 @@ nzl::Program createUniformTestProgram() {
       "#version 330\n"
       "layout (location = 0) in vec3 aPos;\n"
       "out vec4 vertexColor;\n"
+      "uniform float testFloat;"
       "void main() {\n"
-      "gl_Position = vec4(aPos, 1.0);\n"
+      "gl_Position = vec4(aPos, 1.0*testFloat);\n"
       "vertexColor = vec4(0.5,0.0,0.0,1.0);\n}";
 
   std::string fSource =
@@ -177,6 +178,29 @@ TEST(Program, IntUniform) {
                  &value);
 
   EXPECT_EQ(value, 687);
+
+  nzl::terminate();
+}
+
+TEST(Program, FloatUniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{createUniformTestProgram()};
+
+  std::string name = "testFloat";
+
+  program.use();
+  ASSERT_NO_THROW(program.setFloat(name, 687.34f););
+
+  float value = -1000.0f;
+
+  glGetUniformfv(program.id(), glGetUniformLocation(program.id(), name.c_str()),
+                 &value);
+
+  EXPECT_FLOAT_EQ(value, 687.34f);
 
   nzl::terminate();
 }

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -87,6 +87,25 @@ Shader::Shader(Shader::Stage stage, std::string source)
 
 Shader::~Shader() noexcept { glDeleteShader(m_id); }
 
+Shader::Shader(Shader&& other) noexcept
+    : m_id{other.m_id},
+      m_stage(other.stage()),
+      m_source{std::move(other.source())} {
+  other.m_id = 0;
+};
+
+Shader& Shader::operator=(Shader&& other) noexcept {
+  m_id = other.m_id;
+  other.m_id = 0;
+
+  m_source = std::move(other.source());
+  other.m_source = nullptr;
+
+  m_stage = other.m_stage;
+
+  return *this;
+};
+
 Shader::Stage Shader::stage() const noexcept { return m_stage; }
 
 const std::string& Shader::source() const noexcept { return m_source; }

--- a/src/shader.hpp
+++ b/src/shader.hpp
@@ -34,6 +34,10 @@ class Shader {
   /// @brief Destroy this Shader.
   ~Shader() noexcept;
 
+  Shader(Shader&& other) noexcept;
+
+  Shader& operator=(Shader&& other) noexcept;
+
   /// @brief Return the Stage in the rendering pipeline.
   Stage stage() const noexcept;
 
@@ -51,9 +55,9 @@ class Shader {
   void operator=(const Shader&) = delete;
 
  private:
-  const unsigned int m_id;
-  const Stage m_stage;
-  const std::string m_source;
+  unsigned int m_id;
+  Stage m_stage;
+  std::string m_source;
 };
 
 }  // namespace nzl

--- a/src/shader.hpp
+++ b/src/shader.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 // C++ Standard Library
+#include <memory>
 #include <string>
 
 namespace nzl {
@@ -31,13 +32,6 @@ class Shader {
   /// @param source Source code for the shader.
   Shader(Stage stage, std::string source);
 
-  /// @brief Destroy this Shader.
-  ~Shader() noexcept;
-
-  Shader(Shader&& other) noexcept;
-
-  Shader& operator=(Shader&& other) noexcept;
-
   /// @brief Return the Stage in the rendering pipeline.
   Stage stage() const noexcept;
 
@@ -51,11 +45,9 @@ class Shader {
   /// @throws std::runtime_error on compilation failure.
   void compile();
 
-  Shader(const Shader&) = delete;
-  void operator=(const Shader&) = delete;
-
  private:
-  unsigned int m_id;
+  struct IDContainer;
+  std::shared_ptr<IDContainer> p_id{nullptr};
   Stage m_stage;
   std::string m_source;
 };

--- a/src/shader.hpp
+++ b/src/shader.hpp
@@ -47,6 +47,9 @@ class Shader {
   /// @throws std::runtime_error on compilation failure.
   void compile();
 
+  Shader(const Shader&) = delete;
+  void operator=(const Shader&) = delete;
+
  private:
   const unsigned int m_id;
   const Stage m_stage;

--- a/src/shader.t.cpp
+++ b/src/shader.t.cpp
@@ -54,6 +54,43 @@ TEST(Shader, ParameterAccessAndCompilation) {
   nzl::terminate();
 }
 
+TEST(Shader, CopyConstructor) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+  std::string source = "void main() { }";
+
+  nzl::Shader shader1(nzl::Shader::Stage::Fragment, source);
+  nzl::Shader shader2(shader1);
+  EXPECT_STREQ(shader1.source().c_str(), shader2.source().c_str());
+  EXPECT_STREQ(shader2.source().c_str(), source.c_str());
+
+  EXPECT_EQ(shader1.id(), shader2.id());
+  EXPECT_EQ(shader1.stage(), shader2.stage());
+
+  nzl::terminate();
+}
+
+TEST(Shader, CopyOperator) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+  std::string source = "void main() { }";
+
+  nzl::Shader shader1(nzl::Shader::Stage::Fragment, source);
+  nzl::Shader shader2(nzl::Shader::Stage::Vertex, "x");
+
+  shader2 = shader1;
+
+  EXPECT_STREQ(shader1.source().c_str(), shader2.source().c_str());
+  EXPECT_EQ(shader1.id(), shader2.id());
+  EXPECT_EQ(shader1.stage(), shader2.stage());
+
+  nzl::terminate();
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
I was having trouble getting programs to link, and the issue lies in Shader copies prematurely deleting the OpenGL Shader object when their destructor was called. To avoid this problem in the future, it is necessary to disable copying of these classes.

I also fixed a minor issue where the wrong OpenGL function was called to get the Program compilation errors.