### PR TITLE
Set GLFW context version

### DIFF
--- a/src/mxd.cpp
+++ b/src/mxd.cpp
@@ -23,6 +23,8 @@ void initialize() {
   if (auto status = glfwInit(); status == GLFW_FALSE) {
     throw std::runtime_error("Unable to initialize GLFW");
   }
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 };
 
 void terminate() noexcept { glfwTerminate(); }


### PR DESCRIPTION
Certain video drivers (namely the Intel driver for Linux and MacOS) set the OpenGL version to 3.00 by default when a version is not specified. I have therefore set the OpenGL version to 4.3 in order to support compute shaders and GLSL versions beyond 130. I am not sure, however, if this is the right decision, as it will limit the types of video cards that will be compatible with our program. It depends in whether we plan to use compute shaders or not.