### PR TITLE
Add more uniform setters to program class; add line class and tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ set(MXD_SOURCES
   program.cpp
   duration.cpp
   time_point.cpp
+  line.cpp
   )
 
 set(MXD_HEADERS
@@ -36,6 +37,7 @@ set(MXD_HEADERS
   program.hpp
   duration.hpp
   time_point.hpp
+  line.hpp
 )
 
 add_library(mxd
@@ -68,6 +70,7 @@ set(MXD_UNIT_TESTS
   program.t.cpp
   duration.t.cpp
   time_point.t.cpp
+  line.t.cpp
   )
 
 function(make_mxd_test source)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(MXD_SOURCES
   duration.cpp
   time_point.cpp
   line.cpp
+  ellipse.cpp
   )
 
 set(MXD_HEADERS
@@ -38,6 +39,7 @@ set(MXD_HEADERS
   duration.hpp
   time_point.hpp
   line.hpp
+  ellipse.cpp
 )
 
 add_library(mxd
@@ -71,6 +73,7 @@ set(MXD_UNIT_TESTS
   duration.t.cpp
   time_point.t.cpp
   line.t.cpp
+  ellipse.t.cpp
   )
 
 function(make_mxd_test source)

--- a/src/ellipse.cpp
+++ b/src/ellipse.cpp
@@ -1,0 +1,20 @@
+// -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
+
+/// @file      ellipse.cpp
+/// @brief     Implementation of ellipse.hpp.
+/// @author    F. Ayala <19fraayala@asfg.edu.mx>
+/// @date      December 12, 2018
+/// @copyright (C) 2018 Nabla Zero Labs
+
+// Related mxd header
+#include "ellipse.hpp"
+
+// C++ Standard Library
+
+// mxd Library
+
+namespace nzl {
+
+
+
+}  // namespace nzl

--- a/src/ellipse.cpp
+++ b/src/ellipse.cpp
@@ -10,11 +10,145 @@
 #include "ellipse.hpp"
 
 // C++ Standard Library
+#include <cmath>
+#include <iostream>
+#include <memory>
 
 // mxd Library
+#include "program.hpp"
+#include "shader.hpp"
+#include "time_point.hpp"
+
+// Third party libraries
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
+
+namespace {  // anonymous namespace
+nzl::Program create_program() {
+  std::string vertSource =
+      "#version 330 core\n"
+      "layout (location = 0) in vec3 aPos;\n"
+      "void main(){\n"
+      "  gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);\n"
+      "}\n";
+
+  std::string fragSource =
+      "#version 330 core\n"
+      "out vec4 FragColor;\n"
+      "uniform vec3 color;\n"
+      "void main(){\n"
+      "  FragColor = vec4(color, 1.0f);\n"
+      "}\n";
+
+  nzl::Shader vert_shader(nzl::Shader::Stage::Vertex, vertSource);
+  vert_shader.compile();
+
+  nzl::Shader frag_shader(nzl::Shader::Stage::Fragment, fragSource);
+  frag_shader.compile();
+
+  std::vector<nzl::Shader> vec;
+  vec.push_back(vert_shader);
+  vec.push_back(frag_shader);
+
+  nzl::Program program{vec};
+  program.compile();
+
+  return program;
+}
+
+std::vector<glm::vec3> gen_points(float rX, float rY, float number_of_points) {
+  float step_size = 2.0f * 3.14159265358979f / number_of_points;
+
+  std::vector<glm::vec3> points;
+
+  for (int i = 0; i < number_of_points; i++) {
+    float x = rX * cos(i * step_size);
+    float y = rY * sin(i * step_size);
+    points.emplace_back(x, y, 0.0f);
+  }
+
+  return points;
+}
+}  // anonymous namespace
 
 namespace nzl {
 
+struct Ellipse::IDContainer {
+  glm::vec3 m_color;
+  unsigned int m_vao_id;
+  unsigned int m_vbo_id;
+  int m_number_of_points{0};
+  nzl::Program m_program;
 
+  IDContainer(glm::vec3 color, float rX, float rY, float number_of_points)
+      : m_color{color}, m_program{create_program()} {
+    glGenVertexArrays(1, &m_vao_id);
+
+    glBindVertexArray(m_vao_id);
+
+    glGenBuffers(1, &m_vbo_id);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo_id);
+
+    std::vector<glm::vec3> points{gen_points(rX, rY, number_of_points)};
+
+    // Add the first point again, so the first point is connected to the last.
+    points.push_back(points.front());
+
+    m_number_of_points = points.size();
+
+    glBufferData(GL_ARRAY_BUFFER, points.size() * 3 * sizeof(float),
+                 points.data(), GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float),
+                          (void*)0);
+
+    glDisableVertexAttribArray(0);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    glBindVertexArray(0);
+  }
+
+  ~IDContainer() {
+    glDeleteVertexArrays(1, &m_vao_id);
+    glDeleteBuffers(1, &m_vbo_id);
+  }
+};
+
+Ellipse::Ellipse(float rX, float rY, int number_of_points,
+                 glm::vec3 color) noexcept
+    : m_id_container{
+          std::make_shared<IDContainer>(color, rX, rY, number_of_points)} {}
+
+  glm::vec3 Ellipse::color() const noexcept{
+    return m_id_container->m_color;
+  }
+
+  void Ellipse::set_color(glm::vec3 color) noexcept{
+    m_id_container->m_color = color;
+  }
+
+  nzl::Program Ellipse::get_program() const noexcept{
+    return m_id_container->m_program;
+  }
+  
+void Ellipse::do_render(TimePoint t) {
+  m_id_container->m_program.use();
+  m_id_container->m_program.set("color", m_id_container->m_color);
+
+  glBindVertexArray(m_id_container->m_vao_id);
+
+  glEnableVertexAttribArray(0);
+
+  glDrawArrays(GL_LINE_STRIP, 0, m_id_container->m_number_of_points);
+
+  glDisableVertexAttribArray(0);
+
+  glBindVertexArray(0);
+}
 
 }  // namespace nzl

--- a/src/ellipse.hpp
+++ b/src/ellipse.hpp
@@ -1,0 +1,18 @@
+// -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
+
+/// @file      ellipse.hpp
+/// @brief     An ellipse shapethat can be drawn to the screen.
+/// @author    F. Ayala <19fraayala@asfg.edu.mx>
+/// @date      December 12, 2018
+/// @copyright (C) 2018 Nabla Zero Labs
+
+#pragma once
+
+// C++ Standard Library
+
+// mxd Library
+
+namespace nzl {
+
+
+}  // namespace nzl

--- a/src/ellipse.hpp
+++ b/src/ellipse.hpp
@@ -27,8 +27,9 @@ class Ellipse : public Geometry {
   /// @brief Creates an ellipse.
   /// @param rX Radius in the x direction.
   /// @param rY Radius in the y direction.
+  /// @param number_of_points Number of points to be generated for the ellipse.
   /// @param color Color the ellipse will be drawn with.
-  Ellipse(float rX, float rY, glm::vec3 color) noexcept;
+  Ellipse(float rX, float rY, int number_of_points, glm::vec3 color) noexcept;
 
   /// @brief Return the ellipse's color.
   glm::vec3 color() const noexcept;

--- a/src/ellipse.hpp
+++ b/src/ellipse.hpp
@@ -1,7 +1,7 @@
 // -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
 
 /// @file      ellipse.hpp
-/// @brief     An ellipse shapethat can be drawn to the screen.
+/// @brief     An ellipse shape that can be drawn to the screen.
 /// @author    F. Ayala <19fraayala@asfg.edu.mx>
 /// @date      December 12, 2018
 /// @copyright (C) 2018 Nabla Zero Labs
@@ -9,10 +9,43 @@
 #pragma once
 
 // C++ Standard Library
+#include <memory>
+#include <vector>
 
 // mxd Library
+#include "geometry.hpp"
+#include "program.hpp"
+#include "time_point.hpp"
+
+// Third party forward declaration headers
+#include <glm/fwd.hpp>
 
 namespace nzl {
 
+class Ellipse : public Geometry {
+ public:
+  /// @brief Creates an ellipse.
+  /// @param rX Radius in the x direction.
+  /// @param rY Radius in the y direction.
+  /// @param color Color the ellipse will be drawn with.
+  Ellipse(float rX, float rY, glm::vec3 color) noexcept;
+
+  /// @brief Return the ellipse's color.
+  glm::vec3 color() const noexcept;
+
+  /// @brief Sets the ellipse's color.
+  /// @brief color Color to be set.
+  /// @note Affects all copies of this object.
+  void set_color(glm::vec3 color) noexcept;
+
+  /// @brief Returns the program used by the ellipse.
+  nzl::Program get_program() const noexcept;
+
+ private:
+  struct IDContainer;
+  std::shared_ptr<IDContainer> m_id_container{nullptr};
+
+  void do_render(TimePoint t) override;
+};
 
 }  // namespace nzl

--- a/src/ellipse.t.cpp
+++ b/src/ellipse.t.cpp
@@ -1,0 +1,26 @@
+// -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
+
+/// @file      ellipse.t.cpp
+/// @brief     Unit tests for ellipse.hpp.
+/// @author    F. Ayala <19fraayala@asfg.edu.mx>
+/// @date      December 12, 2018
+/// @copyright (C) 2018 Nabla Zero Labs
+
+// Related mxd header
+#include "ellipse.hpp"
+
+// C++ Standard Library
+
+// mxd Library
+
+// Google Test Framework
+#include <gtest/gtest.h>
+
+TEST( ellipse, Failing ) {
+    ASSERT_TRUE( false ) << "You must add unit tests for ellipse.hpp";
+}
+
+int main( int argc, char** argv ) {
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -1,0 +1,20 @@
+// -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
+
+/// @file      line.cpp
+/// @brief     Implementation of line.hpp.
+/// @author    F. Ayala <19fraayala@asfg.edu.mx>
+/// @date      December 11, 2018
+/// @copyright (C) 2018 Nabla Zero Labs
+
+// Related mxd header
+#include "line.hpp"
+
+// C++ Standard Library
+
+// mxd Library
+
+namespace nzl {
+
+
+
+}  // namespace nzl

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -107,25 +107,33 @@ struct Line::IDContainer {
   }
 };
 
-Line::Line() { this->init(glm::vec3(1.0f, 1.0f, 1.0f)); }
+Line::Line() const noexcept { this->init(glm::vec3(1.0f, 1.0f, 1.0f)); }
 
-Line::Line(glm::vec3 color) { this->init(color); }
+Line::Line(glm::vec3 color) noexcept { this->init(color); }
 
-Line::Line(glm::vec3 color, std::vector<glm::vec3> points) {
+Line::Line(glm::vec3 color, std::vector<glm::vec3> points) noexcept {
   this->init(color);
   load_points(points);
 }
 
-void Line::init(glm::vec3 color) {
+void Line::init(glm::vec3 color) noexcept {
   m_id_container = std::make_shared<IDContainer>();
   m_id_container->m_color = color;
 }
 
-void Line::load_points(std::vector<glm::vec3> points) {
+void Line::load_points(std::vector<glm::vec3> points) noexcept {
   m_id_container->load_points(points);
 }
 
 glm::vec3 Line::color() const noexcept { return m_id_container->m_color; }
+
+void Line::set_color(glm::vec3 color) noexcept {
+  m_id_container->m_color = color;
+}
+
+nzl::Program Line::get_program() const noexcept {
+  return m_id_container->m_program;
+}
 
 void Line::do_render(TimePoint t) {
   this->m_id_container->m_program.use();

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -66,6 +66,7 @@ struct Line::IDContainer {
   unsigned int m_vbo_id;
   int m_number_of_points{0};
   nzl::Program m_program;
+  glm::vec3 m_color;
 
   IDContainer() : m_program{create_program()} {
     glGenVertexArrays(1, &m_vao_id);
@@ -115,31 +116,20 @@ Line::Line(glm::vec3 color, std::vector<glm::vec3> points) {
   load_points(points);
 }
 
-Line::Line(const Line& other)
-    : m_id_container{other.m_id_container},
-      m_color{std::make_unique<glm::vec3>(other.color())} {}
-
-Line& Line::operator=(const Line& other) {
-  m_id_container = other.m_id_container;
-  m_color = std::make_unique<glm::vec3>(other.color());
-
-  return *this;
-}
-
 void Line::init(glm::vec3 color) {
-  m_color = std::make_unique<glm::vec3>(color);
   m_id_container = std::make_shared<IDContainer>();
+  m_id_container->m_color = color;
 }
 
 void Line::load_points(std::vector<glm::vec3> points) {
   m_id_container->load_points(points);
 }
 
-glm::vec3 Line::color() const noexcept { return *this->m_color; }
+glm::vec3 Line::color() const noexcept { return m_id_container->m_color; }
 
 void Line::do_render(TimePoint t) {
   this->m_id_container->m_program.use();
-  m_id_container->m_program.set("color", *m_color);
+  m_id_container->m_program.set("color", m_id_container->m_color);
 
   glBindVertexArray(m_id_container->m_vao_id);
 

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -10,11 +10,146 @@
 #include "line.hpp"
 
 // C++ Standard Library
+#include <memory>
+#include <string>
 
 // mxd Library
+#include "program.hpp"
+#include "shader.hpp"
+#include "time_point.hpp"
+
+// Third party libraries
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
+
+namespace {
+
+nzl::Program create_program() {
+  std::string vertSource =
+      "#version 330 core\n"
+      "layout (location = 0) in vec3 aPos;\n"
+      "void main(){\n"
+      "  gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);\n"
+      "}\n";
+
+  std::string fragSource =
+      "#version 330 core\n"
+      "out vec4 FragColor;\n"
+      "uniform vec3 color;\n"
+      "void main(){\n"
+      "  FragColor = vec4(color, 1.0f);\n"
+      "}\n";
+
+  nzl::Shader vert_shader(nzl::Shader::Stage::Vertex, vertSource);
+  vert_shader.compile();
+
+  nzl::Shader frag_shader(nzl::Shader::Stage::Fragment, fragSource);
+  frag_shader.compile();
+
+  std::vector<nzl::Shader> vec;
+  vec.push_back(vert_shader);
+  vec.push_back(frag_shader);
+
+  nzl::Program program{vec};
+  program.compile();
+
+  return program;
+}
+
+}  // anonymous namespace
 
 namespace nzl {
 
+struct Line::IDContainer {
+  unsigned int m_vao_id;
+  unsigned int m_vbo_id;
+  int m_number_of_points{0};
+  nzl::Program m_program;
 
+  IDContainer() : m_program{create_program()} {
+    glGenVertexArrays(1, &m_vao_id);
+
+    glBindVertexArray(m_vao_id);
+
+    glGenBuffers(1, &m_vbo_id);
+
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo_id);
+
+    glBufferData(GL_ARRAY_BUFFER, 0, nullptr, GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float),
+                          (void*)0);
+
+    glDisableVertexAttribArray(0);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+    glBindVertexArray(0);
+  }
+
+  ~IDContainer() {
+    glDeleteVertexArrays(1, &m_vao_id);
+    glDeleteBuffers(1, &m_vbo_id);
+  }
+
+  void load_points(std::vector<glm::vec3> points) {
+    m_number_of_points = points.size();
+    glBindBuffer(GL_ARRAY_BUFFER, m_vbo_id);
+
+    glBufferData(GL_ARRAY_BUFFER, points.size() * 3 * sizeof(float),
+                 points.data(), GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+  }
+};
+
+Line::Line() { this->init(glm::vec3(1.0f, 1.0f, 1.0f)); }
+
+Line::Line(glm::vec3 color) { this->init(color); }
+
+Line::Line(glm::vec3 color, std::vector<glm::vec3> points) {
+  this->init(color);
+  load_points(points);
+}
+
+Line::Line(const Line& other)
+    : m_id_container{other.m_id_container},
+      m_color{std::make_unique<glm::vec3>(other.color())} {}
+
+Line& Line::operator=(const Line& other) {
+  m_id_container = other.m_id_container;
+  m_color = std::make_unique<glm::vec3>(other.color());
+
+  return *this;
+}
+
+void Line::init(glm::vec3 color) {
+  m_color = std::make_unique<glm::vec3>(color);
+  m_id_container = std::make_shared<IDContainer>();
+}
+
+void Line::load_points(std::vector<glm::vec3> points) {
+  m_id_container->load_points(points);
+}
+
+glm::vec3 Line::color() const noexcept { return *this->m_color; }
+
+void Line::do_render(TimePoint t) {
+  this->m_id_container->m_program.use();
+  m_id_container->m_program.set("color", *m_color);
+
+  glBindVertexArray(m_id_container->m_vao_id);
+
+  glEnableVertexAttribArray(0);
+
+  glDrawArrays(GL_LINE_STRIP, 0, m_id_container->m_number_of_points);
+
+  glDisableVertexAttribArray(0);
+
+  glBindVertexArray(0);
+}
 
 }  // namespace nzl

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -107,7 +107,7 @@ struct Line::IDContainer {
   }
 };
 
-Line::Line() const noexcept { this->init(glm::vec3(1.0f, 1.0f, 1.0f)); }
+Line::Line() noexcept { this->init(glm::vec3(1.0f, 1.0f, 1.0f)); }
 
 Line::Line(glm::vec3 color) noexcept { this->init(color); }
 

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -9,10 +9,60 @@
 #pragma once
 
 // C++ Standard Library
+#include <memory>
+#include <vector>
 
 // mxd Library
+#include "geometry.hpp"
+#include "program.hpp"
+#include "time_point.hpp"
+
+#include <glm/glm.hpp>
 
 namespace nzl {
 
+class Line : public Geometry {
+ public:
+  /// @brief Creates line with white color.
+  Line();
+
+  /// @brief Creates line.
+  /// @param color Line color.
+  Line(glm::vec3 color);
+
+  /// @brief Creates line and loads points onto line.
+  /// @param color Line color.
+  /// @param points Points to be loaded into the VBO.
+  Line(glm::vec3 color, std::vector<glm::vec3> points);
+
+  /// @brief Line copy constructor.
+  /// @note Has to make a new unique pointer to color.
+  Line(const Line& other);
+
+  Line& operator=(const Line& other);
+
+  /// @brief Loads points into the line's VBO.
+  /// @param points Points to be loaded into the VBO.
+  /// @note Affects all copies of this object.
+  void load_points(std::vector<glm::vec3> points);
+
+  /// @brief Returns the line's color.
+  glm::vec3 color() const noexcept;
+
+  /// @brief Sets the line's color.
+  /// @param color Color to be set.
+  /// @note Does not affect copies of this object.
+  void set_color(glm::vec3 color) noexcept;
+
+ private:
+  struct IDContainer;
+  std::shared_ptr<IDContainer> m_id_container{nullptr};
+  std::unique_ptr<glm::vec3> m_color;
+
+  void do_render(TimePoint t) override;
+
+  /// @brief Initializes line class.
+  void init(glm::vec3 color);
+};
 
 }  // namespace nzl

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -17,7 +17,7 @@
 #include "program.hpp"
 #include "time_point.hpp"
 
-#include <glm/glm.hpp>
+#include <glm/fwd.hpp>
 
 namespace nzl {
 
@@ -35,12 +35,6 @@ class Line : public Geometry {
   /// @param points Points to be loaded into the VBO.
   Line(glm::vec3 color, std::vector<glm::vec3> points);
 
-  /// @brief Line copy constructor.
-  /// @note Has to make a new unique pointer to color.
-  Line(const Line& other);
-
-  Line& operator=(const Line& other);
-
   /// @brief Loads points into the line's VBO.
   /// @param points Points to be loaded into the VBO.
   /// @note Affects all copies of this object.
@@ -57,10 +51,8 @@ class Line : public Geometry {
  private:
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
-  std::unique_ptr<glm::vec3> m_color;
 
   void do_render(TimePoint t) override;
-
   /// @brief Initializes line class.
   void init(glm::vec3 color);
 };

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -1,7 +1,7 @@
 // -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
 
 /// @file      line.hpp
-/// @brief
+/// @brief     A a series of points that can be drawn as a line
 /// @author    F. Ayala <19fraayala@asfg.edu.mx>
 /// @date      December 11, 2018
 /// @copyright (C) 2018 Nabla Zero Labs
@@ -24,29 +24,32 @@ namespace nzl {
 class Line : public Geometry {
  public:
   /// @brief Creates line with white color.
-  Line();
+  Line() noexcept;
 
   /// @brief Creates line.
   /// @param color Line color.
-  Line(glm::vec3 color);
+  Line(glm::vec3 color) noexcept;
 
   /// @brief Creates line and loads points onto line.
   /// @param color Line color.
   /// @param points Points to be loaded into the VBO.
-  Line(glm::vec3 color, std::vector<glm::vec3> points);
+  Line(glm::vec3 color, std::vector<glm::vec3> points) noexcept;
 
   /// @brief Loads points into the line's VBO.
   /// @param points Points to be loaded into the VBO.
   /// @note Affects all copies of this object.
-  void load_points(std::vector<glm::vec3> points);
+  void load_points(std::vector<glm::vec3> points) noexcept;
 
   /// @brief Returns the line's color.
   glm::vec3 color() const noexcept;
 
   /// @brief Sets the line's color.
   /// @param color Color to be set.
-  /// @note Does not affect copies of this object.
+  /// @note Affects all copies of this object.
   void set_color(glm::vec3 color) noexcept;
+
+  /// @brief the program used by the line.
+  nzl::Program get_program() const noexcept;
 
  private:
   struct IDContainer;
@@ -54,7 +57,7 @@ class Line : public Geometry {
 
   void do_render(TimePoint t) override;
   /// @brief Initializes line class.
-  void init(glm::vec3 color);
+  void init(glm::vec3 color) noexcept;
 };
 
 }  // namespace nzl

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -1,0 +1,18 @@
+// -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
+
+/// @file      line.hpp
+/// @brief
+/// @author    F. Ayala <19fraayala@asfg.edu.mx>
+/// @date      December 11, 2018
+/// @copyright (C) 2018 Nabla Zero Labs
+
+#pragma once
+
+// C++ Standard Library
+
+// mxd Library
+
+namespace nzl {
+
+
+}  // namespace nzl

--- a/src/line.t.cpp
+++ b/src/line.t.cpp
@@ -1,0 +1,26 @@
+// -*- coding:utf-8; mode:c++; mode:auto-fill; fill-column:80; -*-
+
+/// @file      line.t.cpp
+/// @brief     Unit tests for line.hpp.
+/// @author    F. Ayala <19fraayala@asfg.edu.mx>
+/// @date      December 11, 2018
+/// @copyright (C) 2018 Nabla Zero Labs
+
+// Related mxd header
+#include "line.hpp"
+
+// C++ Standard Library
+
+// mxd Library
+
+// Google Test Framework
+#include <gtest/gtest.h>
+
+TEST( line, Failing ) {
+    ASSERT_TRUE( false ) << "You must add unit tests for line.hpp";
+}
+
+int main( int argc, char** argv ) {
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}

--- a/src/line.t.cpp
+++ b/src/line.t.cpp
@@ -10,17 +10,102 @@
 #include "line.hpp"
 
 // C++ Standard Library
+#include <vector>
 
 // mxd Library
+#include "mxd.hpp"
+#include "time_point.hpp"
+#include "window.hpp"
 
 // Google Test Framework
 #include <gtest/gtest.h>
 
-TEST( line, Failing ) {
-    ASSERT_TRUE( false ) << "You must add unit tests for line.hpp";
+// Third party libraries
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
+
+TEST(Line, ConstructorAndParameterAccess) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Test Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Line line(glm::vec3(0.4f, 0.5f, 0.3f));
+
+  EXPECT_FLOAT_EQ(line.color().x, 0.4f);
+  EXPECT_FLOAT_EQ(line.color().y, 0.5f);
+  EXPECT_FLOAT_EQ(line.color().z, 0.3f);
+
+  EXPECT_NE(line.get_program().id(), 0);
+
+  EXPECT_EQ(glGetError(), 0);
+
+  nzl::terminate();
 }
 
-int main( int argc, char** argv ) {
-  ::testing::InitGoogleTest( &argc, argv );
+TEST(Line, OtherConstructors) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Test Window");
+  win.hide();
+  win.make_current();
+
+  std::vector<glm::vec3> points;
+
+  nzl::Line line1;
+  EXPECT_EQ(glGetError(), 0);
+
+  nzl::Line line2(glm::vec3(1.0f, 1.0f, 1.0f));
+  EXPECT_EQ(glGetError(), 0);
+
+  nzl::Line line3(glm::vec3(1.0f, 0.5f, 0.2f), points);
+  EXPECT_EQ(glGetError(), 0);
+
+  nzl::terminate();
+}
+
+TEST(Line, DrawAndReplacePoints) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Test Window");
+  win.hide();
+  win.make_current();
+
+  std::vector<glm::vec3> points;
+  points.emplace_back(-1.0f, 1.0f, 0.0f);
+  points.emplace_back(1.0f, -1.0f, 0.0f);
+
+  nzl::Line line(glm::vec3(1.0f, 1.0f, 0.0f), points);
+
+  for (int i = 0; i < 3; i++) {
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    line.render(nzl::TimePoint());
+
+    win.swap_buffers();
+  }
+  EXPECT_EQ(glGetError(), 0);
+
+  std::vector<glm::vec3> points2;
+  points.emplace_back(-1.0f, -1.0f, 0.0f);
+  points.emplace_back(1.0f, 1.0f, 0.0f);
+
+  line.load_points(points2);
+
+  for (int i = 0; i < 3; i++) {
+    glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    line.render(nzl::TimePoint());
+
+    win.swap_buffers();
+  }
+  EXPECT_EQ(glGetError(), 0);
+
+  nzl::terminate();
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -144,4 +144,8 @@ void Program::set(const std::string& name, const glm::vec3& value) const {
   glUniform3fv(m_id_container->find_uniform_location(name), 1, &value[0]);
 }
 
+void Program::set(const std::string& name, const glm::vec4& value) const {
+  glUniform4fv(m_id_container->find_uniform_location(name), 1, &value[0]);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -140,4 +140,8 @@ void Program::set(const std::string& name, const glm::vec2& value) const {
   glUniform2fv(m_id_container->find_uniform_location(name), 1, &value[0]);
 }
 
+void Program::set(const std::string& name, const glm::vec3& value) const {
+  glUniform3fv(m_id_container->find_uniform_location(name), 1, &value[0]);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -158,4 +158,9 @@ void Program::set(const std::string& name, const glm::mat3& value) const {
                      &value[0][0]);
 }
 
+void Program::set(const std::string& name, const glm::mat4& value) const {
+  glUniformMatrix4fv(m_id_container->find_uniform_location(name), 1, GL_FALSE,
+                     &value[0][0]);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -153,4 +153,9 @@ void Program::set(const std::string& name, const glm::mat2& value) const {
                      &value[0][0]);
 }
 
+void Program::set(const std::string& name, const glm::mat3& value) const {
+  glUniformMatrix3fv(m_id_container->find_uniform_location(name), 1, GL_FALSE,
+                     &value[0][0]);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -148,4 +148,9 @@ void Program::set(const std::string& name, const glm::vec4& value) const {
   glUniform4fv(m_id_container->find_uniform_location(name), 1, &value[0]);
 }
 
+void Program::set(const std::string& name, const glm::mat2& value) const {
+  glUniformMatrix2fv(m_id_container->find_uniform_location(name), 1, GL_FALSE,
+                     &value[0][0]);
+}
+
 }  // namespace nzl

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -24,6 +24,7 @@
 // Third party libraries
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
 
 namespace {  // anonymous namespace
 
@@ -133,6 +134,10 @@ void Program::set(const std::string& name, float x, float y, float z) const {
 void Program::set(const std::string& name, float x, float y, float z,
                   float w) const {
   glUniform4f(m_id_container->find_uniform_location(name), x, y, z, w);
+}
+
+void Program::set(const std::string& name, const glm::vec2& value) const {
+  glUniform2fv(m_id_container->find_uniform_location(name), 1, &value[0]);
 }
 
 }  // namespace nzl

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -15,6 +15,9 @@
 // mxd Library
 #include "shader.hpp"
 
+// Third party forward declaration only headers
+#include <glm/fwd.hpp>
+
 namespace nzl {
 
 class Program {
@@ -75,6 +78,8 @@ class Program {
   /// @param w Fourth value of the vec4 to be set
   void set(const std::string& name, float x, float y, float z, float w) const;
 
+  void set(const std::string& name, const glm::vec2& value) const;
+  
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -102,6 +102,12 @@ class Program {
   /// @param value Mat2 to be set
   void set(const std::string& name, const glm::mat2& value) const;
 
+  /// @brief Sets a mat3 uniform within the Program.
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Mat3 to be set
+  void set(const std::string& name, const glm::mat3& value) const;
+
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -78,8 +78,12 @@ class Program {
   /// @param w Fourth value of the vec4 to be set
   void set(const std::string& name, float x, float y, float z, float w) const;
 
+  /// @brief Sets a vec2 uniform within the Program.
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Vec2 to be set
   void set(const std::string& name, const glm::vec2& value) const;
-  
+
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -90,6 +90,12 @@ class Program {
   /// @param value Vec3 to be set
   void set(const std::string& name, const glm::vec3& value) const;
 
+  /// @brief Sets a vec4 uniform within the Program.
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Vec4 to be set
+  void set(const std::string& name, const glm::vec4& value) const;
+
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -114,6 +114,7 @@ class Program {
   /// @param value Mat4 to be set
   void set(const std::string& name, const glm::mat4& value) const;
 
+ private:
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -108,6 +108,12 @@ class Program {
   /// @param value Mat3 to be set
   void set(const std::string& name, const glm::mat3& value) const;
 
+  /// @brief Sets a mat4 uniform within the Program.
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Mat4 to be set
+  void set(const std::string& name, const glm::mat4& value) const;
+
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -84,6 +84,12 @@ class Program {
   /// @param value Vec2 to be set
   void set(const std::string& name, const glm::vec2& value) const;
 
+  /// @brief Sets a vec3 uniform within the Program.
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Vec3 to be set
+  void set(const std::string& name, const glm::vec3& value) const;
+
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -96,6 +96,12 @@ class Program {
   /// @param value Vec4 to be set
   void set(const std::string& name, const glm::vec4& value) const;
 
+  /// @brief Sets a mat2 uniform within the Program.
+  /// @throws std::runtime_error when uniform not found
+  /// @param name Name of the uniform
+  /// @param value Mat2 to be set
+  void set(const std::string& name, const glm::mat2& value) const;
+
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};
   std::vector<nzl::Shader> m_shaders;

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -37,11 +37,12 @@ nzl::Program create_uniform_test_program() {
       "uniform vec4 testVec4;\n"
       "uniform mat2 testMat2;\n"
       "uniform mat3 testMat3;\n"
+      "uniform mat4 testMat4;\n"
       "void main() {\n"
       "vec3 pos = aPos;\n"
       "pos*=testVec3*testMat3;\n"
       "pos.xy+=testVec2*testMat2;\n"
-      "gl_Position = vec4(pos, 1.0*testFloat);\n"
+      "gl_Position = vec4(pos, 1.0*testFloat)*testMat4;\n"
       "vertexColor = vec4(0.5,0.0,0.0,1.0)*testVec4;\n}";
 
   std::string fSource =
@@ -444,6 +445,40 @@ TEST(Program, Mat3Uniform) {
 
   for (int i = 0; i < 3; i++) {
     for (int z = 0; z < 3; z++) {
+      EXPECT_FLOAT_EQ(ret[i][z], value[i][z]);
+    }
+  }
+
+  EXPECT_FLOAT_EQ(ret[0][0], 123.312f);
+
+  nzl::terminate();
+}
+
+TEST(Program, Mat4Uniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{create_uniform_test_program()};
+
+  std::string name = "testMat4";
+
+  glm::mat4 value(123.312f, 7567.4f, 1565.2f, 823.3f, 643.3f, 795.6f, 98.6f,
+                  342.5f, 396.8f, 231.7f, 95343.3f, 1231234.2f, 329.1f, 1239.3f,
+                  823.31f, 902.3f);
+
+  program.use();
+  ASSERT_NO_THROW(program.set(name, value););
+
+  glm::mat4 ret;
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  4 * 4 * sizeof(float), &ret[0][0]);
+
+  for (int i = 0; i < 4; i++) {
+    for (int z = 0; z < 4; z++) {
       EXPECT_FLOAT_EQ(ret[i][z], value[i][z]);
     }
   }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -35,10 +35,11 @@ nzl::Program create_uniform_test_program() {
       "uniform vec2 testVec2;\n"
       "uniform vec3 testVec3;\n"
       "uniform vec4 testVec4;\n"
+      "uniform mat2 testMat2;\n"
       "void main() {\n"
       "vec3 pos = aPos;\n"
       "pos*=testVec3;\n"
-      "pos.xy+=testVec2;\n"
+      "pos.xy+=testVec2*testMat2;\n"
       "gl_Position = vec4(pos, 1.0*testFloat);\n"
       "vertexColor = vec4(0.5,0.0,0.0,1.0)*testVec4;\n}";
 
@@ -382,6 +383,38 @@ TEST(Program, Vec4Uniform) {
   EXPECT_FLOAT_EQ(ret.y, value.y);
   EXPECT_FLOAT_EQ(ret.z, value.z);
   EXPECT_FLOAT_EQ(ret.w, value.w);
+
+  nzl::terminate();
+}
+
+TEST(Program, Mat2Uniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{create_uniform_test_program()};
+
+  std::string name = "testMat2";
+
+  glm::mat2 value(123.312f, 7567.4f, 1565.2f, 823.3f);
+
+  program.use();
+  ASSERT_NO_THROW(program.set(name, value););
+
+  glm::mat2 ret;
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  2 * 2 * sizeof(float), &ret[0][0]);
+
+  for (int i = 0; i < 2; i++) {
+    for (int z = 0; z < 2; z++) {
+      EXPECT_FLOAT_EQ(ret[i][z], value[i][z]);
+    }
+  }
+
+  EXPECT_FLOAT_EQ(ret[0][0], 123.312f);
 
   nzl::terminate();
 }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -312,10 +312,7 @@ TEST(Program, Vec2Uniform) {
 
   std::string name = "testVec2";
 
-  glm::vec2 value(123.312f,7567.4f);
-
-
-
+  glm::vec2 value(123.312f, 7567.4f);
 
   program.use();
   ASSERT_NO_THROW(program.set(name, value););
@@ -329,7 +326,33 @@ TEST(Program, Vec2Uniform) {
   EXPECT_FLOAT_EQ(ret[0], value.x);
   EXPECT_FLOAT_EQ(ret[1], value.y);
 
+  nzl::terminate();
+}
 
+TEST(Program, Vec3Uniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{create_uniform_test_program()};
+
+  std::string name = "testVec3";
+
+  glm::vec3 value(123.312f, 7567.4f, 1565.2f);
+
+  program.use();
+  ASSERT_NO_THROW(program.set(name, value););
+
+  glm::vec3 ret;
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  4 * sizeof(float), &ret[0]);
+
+  EXPECT_FLOAT_EQ(ret.x, value.x);
+  EXPECT_FLOAT_EQ(ret.y, value.y);
+  EXPECT_FLOAT_EQ(ret.z, value.z);
 
   nzl::terminate();
 }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -23,6 +23,7 @@
 // Third Party Libraries
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
 
 namespace {  // anonymous namespace
 nzl::Program create_uniform_test_program() {
@@ -297,6 +298,38 @@ TEST(Program, 4FloatUniform) {
   EXPECT_FLOAT_EQ(ret[1], val2);
   EXPECT_FLOAT_EQ(ret[2], val3);
   EXPECT_FLOAT_EQ(ret[3], val4);
+
+  nzl::terminate();
+}
+
+TEST(Program, Vec2Uniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{create_uniform_test_program()};
+
+  std::string name = "testVec2";
+
+  glm::vec2 value(123.312f,7567.4f);
+
+
+
+
+  program.use();
+  ASSERT_NO_THROW(program.set(name, value););
+
+  glm::vec2 ret;
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  4 * sizeof(float), &ret[0]);
+
+  EXPECT_FLOAT_EQ(ret[0], value.x);
+  EXPECT_FLOAT_EQ(ret[1], value.y);
+
+
 
   nzl::terminate();
 }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -36,9 +36,10 @@ nzl::Program create_uniform_test_program() {
       "uniform vec3 testVec3;\n"
       "uniform vec4 testVec4;\n"
       "uniform mat2 testMat2;\n"
+      "uniform mat3 testMat3;\n"
       "void main() {\n"
       "vec3 pos = aPos;\n"
-      "pos*=testVec3;\n"
+      "pos*=testVec3*testMat3;\n"
       "pos.xy+=testVec2*testMat2;\n"
       "gl_Position = vec4(pos, 1.0*testFloat);\n"
       "vertexColor = vec4(0.5,0.0,0.0,1.0)*testVec4;\n}";
@@ -410,6 +411,39 @@ TEST(Program, Mat2Uniform) {
 
   for (int i = 0; i < 2; i++) {
     for (int z = 0; z < 2; z++) {
+      EXPECT_FLOAT_EQ(ret[i][z], value[i][z]);
+    }
+  }
+
+  EXPECT_FLOAT_EQ(ret[0][0], 123.312f);
+
+  nzl::terminate();
+}
+
+TEST(Program, Mat3Uniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{create_uniform_test_program()};
+
+  std::string name = "testMat3";
+
+  glm::mat3 value(123.312f, 7567.4f, 1565.2f, 823.3f, 643.3f, 795.6f, 98.6f,
+                  342.5f, 396.8f);
+
+  program.use();
+  ASSERT_NO_THROW(program.set(name, value););
+
+  glm::mat3 ret;
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  3 * 3 * sizeof(float), &ret[0][0]);
+
+  for (int i = 0; i < 3; i++) {
+    for (int z = 0; z < 3; z++) {
       EXPECT_FLOAT_EQ(ret[i][z], value[i][z]);
     }
   }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -357,6 +357,35 @@ TEST(Program, Vec3Uniform) {
   nzl::terminate();
 }
 
+TEST(Program, Vec4Uniform) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Invisible Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Program program{create_uniform_test_program()};
+
+  std::string name = "testVec4";
+
+  glm::vec4 value(123.312f, 7567.4f, 1565.2f, 823.3f);
+
+  program.use();
+  ASSERT_NO_THROW(program.set(name, value););
+
+  glm::vec4 ret;
+
+  glGetnUniformfv(program.id(),
+                  glGetUniformLocation(program.id(), name.c_str()),
+                  4 * sizeof(float), &ret[0]);
+
+  EXPECT_FLOAT_EQ(ret.x, value.x);
+  EXPECT_FLOAT_EQ(ret.y, value.y);
+  EXPECT_FLOAT_EQ(ret.z, value.z);
+  EXPECT_FLOAT_EQ(ret.w, value.w);
+
+  nzl::terminate();
+}
+
 TEST(Program, Failing) {
   ASSERT_TRUE(false) << "You must add unit tests for program.hpp";
 }

--- a/src/program.t.cpp
+++ b/src/program.t.cpp
@@ -488,10 +488,6 @@ TEST(Program, Mat4Uniform) {
   nzl::terminate();
 }
 
-TEST(Program, Failing) {
-  ASSERT_TRUE(false) << "You must add unit tests for program.hpp";
-}
-
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
I've added a few more uniform setters to program, this time taking in glm types. In the program header file, I have decide to include the file GLM/fwd.hpp. This header file forward declares all of the classes in glm, but does not implement them. I did this because glm classes are very laborious to forward declare, making copious use of typedef and other commands. SInce this header file does not include implementation, and only forward declaration, it does not come with the drawbacks that including external headers in a header file has. Thus, I think it is appropriate to use here.

Resolves #14.