### PR TITLE
Rework shader system; add ellipse tests; line improvements

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(MXD_SOURCES
   line.cpp
   ellipse.cpp
   linspace.cpp
+  utilities.cpp
   )
 
 set(MXD_HEADERS
@@ -42,6 +43,7 @@ set(MXD_HEADERS
   line.hpp
   ellipse.hpp
   linspace.hpp
+  utilities.hpp
 )
 
 add_library(mxd
@@ -77,6 +79,7 @@ set(MXD_UNIT_TESTS
   line.t.cpp
   ellipse.t.cpp
   linspace.t.cpp
+  utilities.t.cpp
   )
 
 function(make_mxd_test source)

--- a/src/ellipse.cpp
+++ b/src/ellipse.cpp
@@ -18,6 +18,7 @@
 #include "program.hpp"
 #include "shader.hpp"
 #include "time_point.hpp"
+#include "utilities.hpp"
 
 // Third party libraries
 #include <GL/glew.h>
@@ -26,20 +27,9 @@
 
 namespace {  // anonymous namespace
 nzl::Program create_program() {
-  std::string vertSource =
-      "#version 330 core\n"
-      "layout (location = 0) in vec3 aPos;\n"
-      "void main(){\n"
-      "  gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);\n"
-      "}\n";
+  std::string vertSource = nzl::slurp("../shaders/simple_shader.vert");
 
-  std::string fragSource =
-      "#version 330 core\n"
-      "out vec4 FragColor;\n"
-      "uniform vec3 color;\n"
-      "void main(){\n"
-      "  FragColor = vec4(color, 1.0f);\n"
-      "}\n";
+  std::string fragSource = nzl::slurp("../shaders/simple_shader.vert");
 
   nzl::Shader vert_shader(nzl::Shader::Stage::Vertex, vertSource);
   vert_shader.compile();

--- a/src/ellipse.cpp
+++ b/src/ellipse.cpp
@@ -124,18 +124,16 @@ Ellipse::Ellipse(float rX, float rY, int number_of_points,
     : m_id_container{
           std::make_shared<IDContainer>(color, rX, rY, number_of_points)} {}
 
-  glm::vec3 Ellipse::color() const noexcept{
-    return m_id_container->m_color;
-  }
+glm::vec3 Ellipse::color() const noexcept { return m_id_container->m_color; }
 
-  void Ellipse::set_color(glm::vec3 color) noexcept{
-    m_id_container->m_color = color;
-  }
+void Ellipse::set_color(glm::vec3 color) noexcept {
+  m_id_container->m_color = color;
+}
 
-  nzl::Program Ellipse::get_program() const noexcept{
-    return m_id_container->m_program;
-  }
-  
+nzl::Program Ellipse::get_program() const noexcept {
+  return m_id_container->m_program;
+}
+
 void Ellipse::do_render(TimePoint t) {
   m_id_container->m_program.use();
   m_id_container->m_program.set("color", m_id_container->m_color);

--- a/src/ellipse.t.cpp
+++ b/src/ellipse.t.cpp
@@ -10,14 +10,58 @@
 #include "ellipse.hpp"
 
 // C++ Standard Library
+#include <vector>
 
 // mxd Library
+#include "mxd.hpp"
+#include "time_point.hpp"
+#include "window.hpp"
 
 // Google Test Framework
 #include <gtest/gtest.h>
 
-TEST( ellipse, Failing ) {
-    ASSERT_TRUE( false ) << "You must add unit tests for ellipse.hpp";
+// Third party libraries
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <glm/glm.hpp>
+
+TEST(Ellipse, ConstructorAndParameterAccess) {
+  nzl::initialize();
+  nzl::Window win(600, 600, "Test Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Ellipse ellipse(0.1f, 0.9f, 40, glm::vec3(1.0f,0.0f,0.0f));
+
+  EXPECT_FLOAT_EQ(ellipse.color().x, 1.0f);
+  EXPECT_FLOAT_EQ(ellipse.color().y, 0.0f);
+  EXPECT_FLOAT_EQ(ellipse.color().z, 0.0f);
+
+  EXPECT_NE(ellipse.get_program().id(), 0);
+
+  EXPECT_EQ(glGetError(), 0);
+
+  nzl::terminate();
+}
+
+TEST(Ellipse, Draw){
+  nzl::initialize();
+  nzl::Window win(600,600, "Test Window");
+  win.hide();
+  win.make_current();
+
+  nzl::Ellipse ellipse(0.1f, 0.9f, 40, glm::vec3(1.0f,0.0f,0.0f));
+
+  for(int i = 0; i < 3; i++){
+    glClearColor(0.0f,0.0f,0.0f,1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    ellipse.render(nzl::TimePoint());
+
+    win.swap_buffers();
+  }
+
+  EXPECT_EQ(glGetError(), 0);
 }
 
 int main( int argc, char** argv ) {

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -18,6 +18,7 @@
 #include "program.hpp"
 #include "shader.hpp"
 #include "time_point.hpp"
+#include "utilities.hpp"
 
 // Third party libraries
 #include <GL/glew.h>
@@ -26,23 +27,11 @@
 
 namespace {  // anonymous namespace
 
-/// @TODO Do we really want to hard-code shader sources? What happens if we want
-/// to modify a small detail? Do we need to make a full build? Aren't Shaders
-/// regular source code?
 const std::string vertex_shader_source =
-    "#version 330 core\n"
-    "layout (location = 0) in vec3 aPos;\n"
-    "void main(){\n"
-    "  gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);\n"
-    "}\n";
+    nzl::slurp("../shaders/simple_shader.vert");
 
 const std::string fragment_shader_source =
-    "#version 330 core\n"
-    "out vec4 FragColor;\n"
-    "uniform vec3 color;\n"
-    "void main(){\n"
-    "  FragColor = vec4(color, 1.0f);\n"
-    "}\n";
+    nzl::slurp("../shaders/simple_shader.frag");
 
 /// @TODO This is too ugly. Program needs a full refactoring.
 auto make_program() {

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -121,8 +121,9 @@ glm::vec3 Line::color() const noexcept { return m_pimpl->color; }
 
 void Line::set_color(glm::vec3 color) noexcept { m_pimpl->color = color; }
 
-/// @TODO Shouldn't this return a const reference? Why are we returning a copy?
-nzl::Program Line::get_program() const noexcept { return m_pimpl->program; }
+const nzl::Program& Line::get_program() const noexcept {
+  return m_pimpl->program;
+}
 
 /// @TODO Mark unused variables! Compilation must be 100% clean with no
 /// warnings.

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -65,7 +65,7 @@ struct nzl::Line::LineImp {
   int number_of_points{0};
   glm::vec3 color;
 
-  void load_points(std::vector<glm::vec3> points);
+  void load_points(std::vector<glm::vec3>& points);
 };
 
 nzl::Line::LineImp::LineImp() : program{make_program()} {
@@ -91,7 +91,7 @@ nzl::Line::LineImp::~LineImp() noexcept {
 
 /// @TODO What would happen if points were a very large array? (hint: why are we
 /// not passing by reference or moving; why don't I have a point array).
-void nzl::Line::LineImp::load_points(std::vector<glm::vec3> points) {
+void nzl::Line::LineImp::load_points(std::vector<glm::vec3>& points) {
   number_of_points = points.size();
   glBindBuffer(GL_ARRAY_BUFFER, vbo_id);
   glBufferData(GL_ARRAY_BUFFER, points.size() * 3 * sizeof(float),
@@ -109,11 +109,11 @@ Line::Line(glm::vec3 color) : m_pimpl{std::make_shared<Line::LineImp>()} {
 
 Line::Line() : Line(glm::vec3(1.0f, 1.0f, 1.0f)) {}
 
-Line::Line(glm::vec3 color, std::vector<glm::vec3> points) : Line(color) {
+Line::Line(glm::vec3 color, std::vector<glm::vec3>& points) : Line(color) {
   m_pimpl->load_points(points);
 }
 
-void Line::load_points(std::vector<glm::vec3> points) noexcept {
+void Line::load_points(std::vector<glm::vec3>& points) noexcept {
   m_pimpl->load_points(points);
 }
 

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -124,6 +124,10 @@ Line::Line(glm::vec3 color, std::vector<glm::vec3> points) : Line(color) {
   m_pimpl->load_points(points);
 }
 
+void Line::load_points(std::vector<glm::vec3> points) noexcept {
+  m_pimpl->load_points(points);
+}
+
 glm::vec3 Line::color() const noexcept { return m_pimpl->color; }
 
 void Line::set_color(glm::vec3 color) noexcept { m_pimpl->color = color; }

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -52,7 +52,7 @@ class Line : public Geometry {
   void set_color(glm::vec3 color) noexcept;
 
   /// @brief the program used by the line.
-  nzl::Program get_program() const noexcept;
+  const nzl::Program& get_program() const noexcept;
 
  private:
   struct LineImp;

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -36,12 +36,12 @@ class Line : public Geometry {
   /// @brief Creates line and loads points onto line.
   /// @param color Line color.
   /// @param points Points to be loaded into the VBO.
-  Line(glm::vec3 color, std::vector<glm::vec3> points);
+  Line(glm::vec3 color, std::vector<glm::vec3>& points);
 
   /// @brief Loads points into the line's VBO.
   /// @param points Points to be loaded into the VBO.
   /// @note Affects all copies of this object.
-  void load_points(std::vector<glm::vec3> points) noexcept;
+  void load_points(std::vector<glm::vec3>& points) noexcept;
 
   /// @brief Returns the line's color.
   glm::vec3 color() const noexcept;

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -98,8 +98,14 @@ Program::Program(std::vector<nzl::Shader> shaders)
     : m_id_container{std::make_shared<IDContainer>(create_program())},
       m_shaders{shaders} {}
 
+Program::Program()
+    : m_id_container{std::make_shared<IDContainer>(create_program())} {}
+
 void Program::compile() {
   for (auto&& s : m_shaders) {
+    if (!s.is_compiled()) {
+      s.compile();
+    }
     glAttachShader(m_id_container->m_id, s.id());
   }
 
@@ -110,6 +116,8 @@ void Program::compile() {
 unsigned int Program::id() const noexcept { return m_id_container->m_id; }
 
 void Program::use() const noexcept { glUseProgram(m_id_container->m_id); }
+
+void Program::add_shader(nzl::Shader& shader) { m_shaders.push_back(shader); }
 
 void Program::set(const std::string& name, bool value) const {
   glUniform1i(m_id_container->find_uniform_location(name), (int)value);

--- a/src/program.hpp
+++ b/src/program.hpp
@@ -26,8 +26,12 @@ class Program {
   /// @param shaders Shaders to be used to create this Program.
   Program(std::vector<nzl::Shader> shaders);
 
+  /// @brief Creates a Program with an empty @link Shader@endlink vector.
+  Program();
+
   /// @brief Links and compiles this Program.
   /// @throws std::runtime_error on compilation failure.
+  /// @note If a shader in the vector is not compiled, the Program compiles it.
   void compile();
 
   /// @brief Return an identifier associated with this Program.
@@ -35,6 +39,10 @@ class Program {
 
   /// @brief Calls glUseProgram() with this program's id
   void use() const noexcept;
+
+  /// @brief Adds a @link Shader@endlink to the program
+  /// @param shader Shader to be added
+  void add_shader(nzl::Shader& shader);
 
   /// @brief Sets a boolean uniform within the Program.
   /// @throws std::runtime_error when uniform not found

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -85,6 +85,7 @@ namespace nzl {
 
 struct Shader::IDContainer {
   const unsigned int m_id;
+  bool m_compiled{false};
 
   IDContainer(unsigned int id) noexcept : m_id{id} {}
 
@@ -108,6 +109,9 @@ void Shader::compile() {
   glShaderSource(m_id_container->m_id, 1, &source_ptr, &source_size);
   glCompileShader(m_id_container->m_id);
   check_compilation_errors(m_id_container->m_id);
+  m_id_container->m_compiled = true;
 }
+
+bool Shader::is_compiled() const noexcept { return m_id_container->m_compiled; }
 
 }  // namespace nzl

--- a/src/shader.hpp
+++ b/src/shader.hpp
@@ -45,6 +45,9 @@ class Shader {
   /// @throws std::runtime_error on compilation failure.
   void compile();
 
+  /// @brief Returns whether the Shader has been compiled.
+  bool is_compiled() const noexcept;
+
  private:
   struct IDContainer;
   std::shared_ptr<IDContainer> m_id_container{nullptr};

--- a/src/shaders/simple_shader.frag
+++ b/src/shaders/simple_shader.frag
@@ -1,0 +1,4 @@
+#version 330 core
+out vec4 FragColor;
+uniform vec3 color;
+void main() { FragColor = vec4(color, 1.0f); }

--- a/src/shaders/simple_shader.vert
+++ b/src/shaders/simple_shader.vert
@@ -1,0 +1,3 @@
+#version 330 core
+layout(location = 0) in vec3 aPos;
+void main() { gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0); }

--- a/src/time_point.cpp
+++ b/src/time_point.cpp
@@ -14,4 +14,6 @@
 // mxd Library
 #include "duration.hpp"
 
-namespace nzl {}  // namespace nzl
+namespace nzl {
+  TimePoint::TimePoint(Duration duration) noexcept{}
+}  // namespace nzl


### PR DESCRIPTION
I've done a few changes to the shaders in order to make them a bit more intutive, let me know if this is enough:
-Shader now keeps track of whether it has been compiled
-Program can be initialized without a shader vector
-Shaders can be added to a program after it has been initialized
-When programs are compiled, they compile shaders that have not been compiled.

I also added some tests for the ellipse component. I will be moving ellipse to a pimpl structure soon enough.