### PR TITLE
Implement Time Point class

### DIFF
--- a/src/duration.cpp
+++ b/src/duration.cpp
@@ -100,4 +100,16 @@ bool operator<(const Duration& lhs, const Duration& rhs) noexcept {
   return lhs.seconds() < rhs.seconds();
 }
 
+bool operator!=(const Duration& lhs, const Duration& rhs) noexcept {
+  return lhs.seconds() != rhs.seconds();
+}
+
+bool operator>=(const Duration& lhs, const Duration& rhs) noexcept {
+  return lhs.seconds() >= rhs.seconds();
+}
+
+bool operator<=(const Duration& lhs, const Duration& rhs) noexcept {
+  return lhs.seconds() <= rhs.seconds();
+}
+
 }  // namespace nzl

--- a/src/duration.hpp
+++ b/src/duration.hpp
@@ -51,5 +51,8 @@ Duration operator/(const Duration& lhs, double denominator) noexcept;
 
 bool operator>(const Duration& lhs, const Duration& rhs) noexcept;
 bool operator<(const Duration& lhs, const Duration& rhs) noexcept;
+bool operator!=(const Duration& lhs, const Duration& rhs) noexcept;
+bool operator>=(const Duration& lhs, const Duration& rhs) noexcept;
+bool operator<=(const Duration& lhs, const Duration& rhs) noexcept;
 
 }  // namespace nzl

--- a/src/duration.t.cpp
+++ b/src/duration.t.cpp
@@ -26,7 +26,7 @@ TEST(Duration, DefaultConstructorIsZero) {
   ASSERT_EQ(d.seconds(), 0.0);
 }
 
-TEST(duration, ConstructorCreatesCorrectDurationObjects) {
+TEST(Duration, ConstructorCreatesCorrectDurationObjects) {
   EXPECT_DOUBLE_EQ(nzl::Duration::Years(1).seconds(), 365.25 * 24 * 60 * 60);
   EXPECT_DOUBLE_EQ(nzl::Duration::Days(1).seconds(), 24 * 60 * 60);
   EXPECT_DOUBLE_EQ(nzl::Duration::Hours(1).seconds(), 60 * 60);
@@ -90,7 +90,7 @@ TEST(Duration, BooleanOperators) {
   EXPECT_FALSE(lesser_duration > bigger_duration);
 }
 
-TEST(duration, GreaterThanOrEqualOperator) {
+TEST(Duration, GreaterThanOrEqualOperator) {
   nzl::Duration bigger_duration{nzl::Duration::Years(1)};
   nzl::Duration lesser_duration{nzl::Duration::Days(10)};
   nzl::Duration almost_bigger_duration{nzl::Duration::Years(0.999999)};
@@ -101,7 +101,7 @@ TEST(duration, GreaterThanOrEqualOperator) {
   EXPECT_TRUE(bigger_duration >= bigger_duration);
 }
 
-TEST(duration, LessThanOrEqualOperator) {
+TEST(Duration, LessThanOrEqualOperator) {
   nzl::Duration bigger_duration{nzl::Duration::Years(1)};
   nzl::Duration lesser_duration{nzl::Duration::Days(10)};
   nzl::Duration almost_lesser_duration{nzl::Duration::Years(1.0000001)};
@@ -112,7 +112,7 @@ TEST(duration, LessThanOrEqualOperator) {
   EXPECT_TRUE(bigger_duration <= bigger_duration);
 }
 
-TEST(duration, NotEqualOperator) {
+TEST(Duration, NotEqualOperator) {
   nzl::Duration duration{nzl::Duration::Years(1)};
   nzl::Duration different_duration{nzl::Duration::Days(1)};
 

--- a/src/duration.t.cpp
+++ b/src/duration.t.cpp
@@ -26,21 +26,21 @@ TEST(Duration, DefaultConstructorIsZero) {
   ASSERT_EQ(d.seconds(), 0.0);
 }
 
-TEST(Duration, ConstructorCreatesCorrectDurationObjects) {
-  ASSERT_DOUBLE_EQ(nzl::Duration::Years(1).seconds(), 365.25 * 24 * 60 * 60);
-  ASSERT_DOUBLE_EQ(nzl::Duration::Days(1).seconds(), 24 * 60 * 60);
-  ASSERT_DOUBLE_EQ(nzl::Duration::Hours(1).seconds(), 60 * 60);
-  ASSERT_DOUBLE_EQ(nzl::Duration::Minutes(1).seconds(), 60);
-  ASSERT_DOUBLE_EQ(nzl::Duration::Seconds(1).seconds(), 1);
+TEST(duration, ConstructorCreatesCorrectDurationObjects) {
+  EXPECT_DOUBLE_EQ(nzl::Duration::Years(1).seconds(), 365.25 * 24 * 60 * 60);
+  EXPECT_DOUBLE_EQ(nzl::Duration::Days(1).seconds(), 24 * 60 * 60);
+  EXPECT_DOUBLE_EQ(nzl::Duration::Hours(1).seconds(), 60 * 60);
+  EXPECT_DOUBLE_EQ(nzl::Duration::Minutes(1).seconds(), 60);
+  EXPECT_DOUBLE_EQ(nzl::Duration::Seconds(1).seconds(), 1);
 }
 
 TEST(Duration, UnitConversions) {
   nzl::Duration test_duration{nzl::Duration::Seconds(1000000)};
-  ASSERT_DOUBLE_EQ(test_duration.years(), 1000000.0 / (365.25 * 24 * 60 * 60));
-  ASSERT_DOUBLE_EQ(test_duration.days(), 1000000.0 / (24 * 60 * 60));
-  ASSERT_DOUBLE_EQ(test_duration.hours(), 1000000.0 / (60 * 60));
-  ASSERT_DOUBLE_EQ(test_duration.minutes(), 1000000.0 / 60);
-  ASSERT_DOUBLE_EQ(test_duration.seconds(), 1000000.0);
+  EXPECT_DOUBLE_EQ(test_duration.years(), 1000000.0 / (365.25 * 24 * 60 * 60));
+  EXPECT_DOUBLE_EQ(test_duration.days(), 1000000.0 / (24 * 60 * 60));
+  EXPECT_DOUBLE_EQ(test_duration.hours(), 1000000.0 / (60 * 60));
+  EXPECT_DOUBLE_EQ(test_duration.minutes(), 1000000.0 / 60);
+  EXPECT_DOUBLE_EQ(test_duration.seconds(), 1000000.0);
 }
 
 TEST(Duration, PlusEqualOperator) {
@@ -73,10 +73,10 @@ TEST(Duration, AlgebraicOperators) {
   nzl::Duration ten_day_duration{nzl::Duration::Days(10)};
   nzl::Duration twenty_day_duration{nzl::Duration::Days(20)};
 
-  ASSERT_DOUBLE_EQ((ten_day_duration + twenty_day_duration).days(), 30.0);
-  ASSERT_DOUBLE_EQ((ten_day_duration - twenty_day_duration).days(), -10.0);
-  ASSERT_DOUBLE_EQ((ten_day_duration * 20).days(), 200.0);
-  ASSERT_DOUBLE_EQ((ten_day_duration / 20).days(), 0.5);
+  EXPECT_DOUBLE_EQ((ten_day_duration + twenty_day_duration).days(), 30.0);
+  EXPECT_DOUBLE_EQ((ten_day_duration - twenty_day_duration).days(), -10.0);
+  EXPECT_DOUBLE_EQ((ten_day_duration * 20).days(), 200.0);
+  EXPECT_DOUBLE_EQ((ten_day_duration / 20).days(), 0.5);
 }
 
 TEST(Duration, BooleanOperators) {
@@ -84,10 +84,40 @@ TEST(Duration, BooleanOperators) {
   nzl::Duration lesser_duration{nzl::Duration::Seconds(60)};
   nzl::Duration equal_duration{nzl::Duration::Minutes(1)};
 
-  ASSERT_TRUE(bigger_duration > lesser_duration);
-  ASSERT_TRUE(lesser_duration < bigger_duration);
-  ASSERT_FALSE(lesser_duration < equal_duration);
-  ASSERT_FALSE(lesser_duration > bigger_duration);
+  EXPECT_TRUE(bigger_duration > lesser_duration);
+  EXPECT_TRUE(lesser_duration < bigger_duration);
+  EXPECT_FALSE(lesser_duration < equal_duration);
+  EXPECT_FALSE(lesser_duration > bigger_duration);
+}
+
+TEST(duration, GreaterThanOrEqualOperator) {
+  nzl::Duration bigger_duration{nzl::Duration::Years(1)};
+  nzl::Duration lesser_duration{nzl::Duration::Days(10)};
+  nzl::Duration almost_bigger_duration{nzl::Duration::Years(0.999999)};
+
+  EXPECT_TRUE(bigger_duration >= lesser_duration);
+  EXPECT_FALSE(lesser_duration >= bigger_duration);
+  EXPECT_FALSE(almost_bigger_duration >= bigger_duration);
+  EXPECT_TRUE(bigger_duration >= bigger_duration);
+}
+
+TEST(duration, LessThanOrEqualOperator) {
+  nzl::Duration bigger_duration{nzl::Duration::Years(1)};
+  nzl::Duration lesser_duration{nzl::Duration::Days(10)};
+  nzl::Duration almost_lesser_duration{nzl::Duration::Years(1.0000001)};
+
+  EXPECT_TRUE(lesser_duration <= bigger_duration);
+  EXPECT_FALSE(bigger_duration <= lesser_duration);
+  EXPECT_FALSE(almost_lesser_duration <= bigger_duration);
+  EXPECT_TRUE(bigger_duration <= bigger_duration);
+}
+
+TEST(duration, NotEqualOperator) {
+  nzl::Duration duration{nzl::Duration::Years(1)};
+  nzl::Duration different_duration{nzl::Duration::Days(1)};
+
+  EXPECT_TRUE(duration != different_duration);
+  EXPECT_FALSE(duration != duration);
 }
 
 int main(int argc, char** argv) {

--- a/src/time_point.cpp
+++ b/src/time_point.cpp
@@ -12,6 +12,72 @@
 // C++ Standard Library
 
 // mxd Library
+#include <limits>
 #include "duration.hpp"
 
-namespace nzl {}  // namespace nzl
+namespace nzl {
+
+TimePoint TimePoint::Julian(double days) {
+  return TimePoint{Duration::Days(days)};
+}
+
+TimePoint TimePoint::DistantPast() noexcept {
+  return TimePoint(
+      Duration::Seconds(std::numeric_limits<double>::infinity() * -1));
+}
+
+TimePoint TimePoint::DistantFuture() noexcept {
+  return TimePoint(Duration::Seconds(std::numeric_limits<double>::infinity()));
+}
+
+TimePoint::TimePoint(Duration duration) noexcept { m_duration = duration; }
+
+Duration TimePoint::elapsed() const noexcept { return m_duration; }
+
+TimePoint& TimePoint::operator+=(const Duration& duration) {
+  m_duration += duration;
+  return *this;
+}
+
+TimePoint& TimePoint::operator-=(const Duration& duration) {
+  m_duration -= duration;
+  return *this;
+}
+
+TimePoint operator+(const TimePoint& lhs, const Duration& rhs) {
+  auto copy = lhs;
+  copy += rhs;
+  return copy;
+}
+
+TimePoint operator-(const TimePoint& lhs, const Duration& rhs) {
+  auto copy = lhs;
+  copy -= rhs;
+  return copy;
+}
+
+Duration operator-(const TimePoint& lhs, const TimePoint& rhs) {
+  return (lhs - rhs.elapsed()).elapsed();
+}
+
+bool operator<(const TimePoint& lhs, const TimePoint& rhs) {
+  return lhs.elapsed() < rhs.elapsed();
+}
+
+bool operator>(const TimePoint& lhs, const TimePoint& rhs) {
+  return lhs.elapsed() > rhs.elapsed();
+}
+
+bool operator<=(const TimePoint& lhs, const TimePoint& rhs) {
+  return lhs.elapsed() <= rhs.elapsed();
+}
+
+bool operator>=(const TimePoint& lhs, const TimePoint& rhs) {
+  return lhs.elapsed() >= rhs.elapsed();
+}
+
+bool operator!=(const TimePoint& lhs, const TimePoint& rhs) {
+  return lhs.elapsed() != rhs.elapsed();
+}
+
+}  // namespace nzl

--- a/src/time_point.hpp
+++ b/src/time_point.hpp
@@ -17,12 +17,17 @@ namespace nzl {
 class TimePoint {
  public:
   /// @brief Build a timepoint from a count of Julian days.
-  static TimePoint Julian(double);
+  static TimePoint Julian(double days);
+
+  /// @return TimePoint whose m_duration is of negative infinity.
   static TimePoint DistantPast() noexcept;
+
+  /// @return TimePoint whose m_duration is of infinity.
   static TimePoint DistantFuture() noexcept;
 
   /// @brief Build a TimePoint.
   /// @param duration Elapsed duration from the J2000 epoch.
+  /// @note Default constructor is a duration with value 0.
   TimePoint(Duration duration = Duration()) noexcept;
 
   /// @brief Return the duration elapsed from the J2000 epoch.

--- a/src/time_point.t.cpp
+++ b/src/time_point.t.cpp
@@ -16,8 +16,127 @@
 // Google Test Framework
 #include <gtest/gtest.h>
 
-TEST(TimePoint, Failing) {
-  ASSERT_TRUE(false) << "You must add unit tests for time_point.hpp";
+/// @note included std limits for DistantPast & DistantFuture tests.
+#include <limits>
+
+TEST(time_point, ConstructorDefaultIsZero) {
+  ASSERT_EQ(nzl::TimePoint().elapsed().seconds(), 0.0);
+}
+
+TEST(time_point, ConstructorValueIsCorrect) {
+  ASSERT_DOUBLE_EQ(
+      nzl::TimePoint(nzl::Duration::Minutes(100)).elapsed().minutes(), 100);
+}
+
+TEST(time_point, JulianDayConstructorEqualsDayDuration) {
+  ASSERT_DOUBLE_EQ(
+      nzl::TimePoint::Julian(365).elapsed().seconds(),
+      nzl::TimePoint(nzl::Duration::Days(365)).elapsed().seconds());
+}
+
+TEST(time_point, NoValueLessThanDistantPast) {
+  nzl::TimePoint infinite_past = nzl::TimePoint::DistantPast();
+  double min_value = std::numeric_limits<double>::min();
+
+  ASSERT_TRUE(infinite_past.elapsed().seconds() < min_value);
+}
+
+TEST(time_point, NoValueGreaterThanDistantFuture) {
+  nzl::TimePoint infinite_future = nzl::TimePoint::DistantFuture();
+  double max_value = std::numeric_limits<double>::max();
+
+  ASSERT_TRUE(infinite_future.elapsed().seconds() > max_value);
+}
+
+TEST(time_point, PlusEqualOperatorWorks) {
+  nzl::TimePoint j200_epoch = nzl::TimePoint();
+  nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
+  ASSERT_DOUBLE_EQ((j200_epoch += ten_seconds).elapsed().seconds(), 10.0);
+}
+
+TEST(time_point, MinusEqualOperatorWorks) {
+  nzl::TimePoint j200_epoch = nzl::TimePoint();
+  nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
+  ASSERT_DOUBLE_EQ((j200_epoch -= ten_seconds).elapsed().seconds(), -10.0);
+}
+
+TEST(time_point, PlusOperatorWorks) {
+  nzl::TimePoint j200_epoch = nzl::TimePoint();
+  nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
+
+  ASSERT_DOUBLE_EQ((j200_epoch + ten_seconds).elapsed().seconds(), 10.0);
+}
+
+TEST(time_point, MinusOperatorWorks) {
+  nzl::TimePoint j200_epoch = nzl::TimePoint();
+  nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
+
+  ASSERT_DOUBLE_EQ((j200_epoch - ten_seconds).elapsed().seconds(), -10.0);
+}
+
+TEST(time_point, TimePointDifferenceOperatorWorks) {
+  nzl::TimePoint two_days_after_j200 = nzl::TimePoint(nzl::Duration::Days(2));
+  nzl::TimePoint thousand_minutes_after_j200 =
+      nzl::TimePoint(nzl::Duration::Minutes(1000));
+
+  EXPECT_DOUBLE_EQ(
+      (two_days_after_j200 - thousand_minutes_after_j200).minutes(),
+      (2 * 24 * 60 - 1000.0));
+  EXPECT_DOUBLE_EQ(
+      (thousand_minutes_after_j200 - two_days_after_j200).minutes(),
+      (1000.0 - 2 * 24 * 60));
+}
+
+TEST(time_point, NotEqualOperatorWorks) {
+  nzl::TimePoint time_point = nzl::TimePoint::Julian(1000);
+  nzl::TimePoint different_time_point = nzl::TimePoint::Julian(999);
+
+  EXPECT_TRUE(time_point != different_time_point);
+  EXPECT_FALSE(time_point != time_point);
+}
+
+TEST(time_point, LessThanOperator) {
+  nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
+  nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
+  nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};
+
+  EXPECT_TRUE(small_time_point < big_time_point);
+  EXPECT_FALSE(big_time_point < small_time_point);
+  EXPECT_FALSE(big_time_point < almost_big_time_point);
+  EXPECT_FALSE(big_time_point < big_time_point);
+}
+
+TEST(time_point, GreaterThanOperator) {
+  nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
+  nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
+  nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};
+
+  EXPECT_TRUE(big_time_point > small_time_point);
+  EXPECT_FALSE(small_time_point > big_time_point);
+  EXPECT_FALSE(almost_big_time_point > big_time_point);
+  EXPECT_FALSE(big_time_point > big_time_point);
+}
+
+TEST(time_point, LessThanOrEqualOperator) {
+  nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
+  nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
+  nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};
+
+  EXPECT_TRUE(small_time_point <= big_time_point);
+  EXPECT_FALSE(big_time_point <= small_time_point);
+  EXPECT_FALSE(big_time_point <= almost_big_time_point);
+  EXPECT_TRUE(big_time_point <= big_time_point);
+}
+
+TEST(time_point, GreaterThanOrEqualOperator) {
+  nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
+  nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
+  nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};
+
+  EXPECT_TRUE(big_time_point >= small_time_point);
+  EXPECT_FALSE(small_time_point >= big_time_point);
+  EXPECT_FALSE(almost_big_time_point >= big_time_point);
+  EXPECT_TRUE(big_time_point >= big_time_point);
 }
 
 int main(int argc, char** argv) {

--- a/src/time_point.t.cpp
+++ b/src/time_point.t.cpp
@@ -19,62 +19,62 @@
 /// @note included std limits for DistantPast & DistantFuture tests.
 #include <limits>
 
-TEST(time_point, ConstructorDefaultIsZero) {
+TEST(Time_point, ConstructorDefaultIsZero) {
   ASSERT_EQ(nzl::TimePoint().elapsed().seconds(), 0.0);
 }
 
-TEST(time_point, ConstructorValueIsCorrect) {
+TEST(Time_point, ConstructorValueIsCorrect) {
   ASSERT_DOUBLE_EQ(
       nzl::TimePoint(nzl::Duration::Minutes(100)).elapsed().minutes(), 100);
 }
 
-TEST(time_point, JulianDayConstructorEqualsDayDuration) {
+TEST(Time_point, JulianDayConstructorEqualsDayDuration) {
   ASSERT_DOUBLE_EQ(
       nzl::TimePoint::Julian(365).elapsed().seconds(),
       nzl::TimePoint(nzl::Duration::Days(365)).elapsed().seconds());
 }
 
-TEST(time_point, NoValueLessThanDistantPast) {
+TEST(Time_point, NoValueLessThanDistantPast) {
   nzl::TimePoint infinite_past = nzl::TimePoint::DistantPast();
   double min_value = std::numeric_limits<double>::min();
 
   ASSERT_TRUE(infinite_past.elapsed().seconds() < min_value);
 }
 
-TEST(time_point, NoValueGreaterThanDistantFuture) {
+TEST(Time_point, NoValueGreaterThanDistantFuture) {
   nzl::TimePoint infinite_future = nzl::TimePoint::DistantFuture();
   double max_value = std::numeric_limits<double>::max();
 
   ASSERT_TRUE(infinite_future.elapsed().seconds() > max_value);
 }
 
-TEST(time_point, PlusEqualOperatorWorks) {
+TEST(Time_point, PlusEqualOperatorWorks) {
   nzl::TimePoint j200_epoch = nzl::TimePoint();
   nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
   ASSERT_DOUBLE_EQ((j200_epoch += ten_seconds).elapsed().seconds(), 10.0);
 }
 
-TEST(time_point, MinusEqualOperatorWorks) {
+TEST(Time_point, MinusEqualOperatorWorks) {
   nzl::TimePoint j200_epoch = nzl::TimePoint();
   nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
   ASSERT_DOUBLE_EQ((j200_epoch -= ten_seconds).elapsed().seconds(), -10.0);
 }
 
-TEST(time_point, PlusOperatorWorks) {
+TEST(Time_point, PlusOperatorWorks) {
   nzl::TimePoint j200_epoch = nzl::TimePoint();
   nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
 
   ASSERT_DOUBLE_EQ((j200_epoch + ten_seconds).elapsed().seconds(), 10.0);
 }
 
-TEST(time_point, MinusOperatorWorks) {
+TEST(Time_point, MinusOperatorWorks) {
   nzl::TimePoint j200_epoch = nzl::TimePoint();
   nzl::Duration ten_seconds = nzl::Duration::Seconds(10);
 
   ASSERT_DOUBLE_EQ((j200_epoch - ten_seconds).elapsed().seconds(), -10.0);
 }
 
-TEST(time_point, TimePointDifferenceOperatorWorks) {
+TEST(Time_point, TimePointDifferenceOperatorWorks) {
   nzl::TimePoint two_days_after_j200 = nzl::TimePoint(nzl::Duration::Days(2));
   nzl::TimePoint thousand_minutes_after_j200 =
       nzl::TimePoint(nzl::Duration::Minutes(1000));
@@ -87,7 +87,7 @@ TEST(time_point, TimePointDifferenceOperatorWorks) {
       (1000.0 - 2 * 24 * 60));
 }
 
-TEST(time_point, NotEqualOperatorWorks) {
+TEST(Time_point, NotEqualOperatorWorks) {
   nzl::TimePoint time_point = nzl::TimePoint::Julian(1000);
   nzl::TimePoint different_time_point = nzl::TimePoint::Julian(999);
 
@@ -95,7 +95,7 @@ TEST(time_point, NotEqualOperatorWorks) {
   EXPECT_FALSE(time_point != time_point);
 }
 
-TEST(time_point, LessThanOperator) {
+TEST(Time_point, LessThanOperator) {
   nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
   nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
   nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};
@@ -106,7 +106,7 @@ TEST(time_point, LessThanOperator) {
   EXPECT_FALSE(big_time_point < big_time_point);
 }
 
-TEST(time_point, GreaterThanOperator) {
+TEST(Time_point, GreaterThanOperator) {
   nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
   nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
   nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};
@@ -117,7 +117,7 @@ TEST(time_point, GreaterThanOperator) {
   EXPECT_FALSE(big_time_point > big_time_point);
 }
 
-TEST(time_point, LessThanOrEqualOperator) {
+TEST(Time_point, LessThanOrEqualOperator) {
   nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
   nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
   nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};
@@ -128,7 +128,7 @@ TEST(time_point, LessThanOrEqualOperator) {
   EXPECT_TRUE(big_time_point <= big_time_point);
 }
 
-TEST(time_point, GreaterThanOrEqualOperator) {
+TEST(Time_point, GreaterThanOrEqualOperator) {
   nzl::TimePoint big_time_point{nzl::TimePoint::Julian(1000)};
   nzl::TimePoint small_time_point{nzl::TimePoint::Julian(10)};
   nzl::TimePoint almost_big_time_point{nzl::TimePoint::Julian(999.9999)};


### PR DESCRIPTION
I implemented the Time_point class operators and functions, and the tests.
- To implement the !=, <= and >= operators in the Time Point class, I decided to implement !=, <= and >= in the Duration class too, so that I could call them on the respective Time Point operators. I believe this makes the code more understandable, and they could be useful in  case they are needed in the future.
- For the Time Point tests, I created a test for every method and operator. I used EXPECT instead of ASSERT, so that  the test continues in case some condition fails, so we can see if the other conditions also fail, and fix it easier.
- For the Distant Future and Distant Past methods, I used std::numeric_limits, method infinity(). I used the tests to make sure no double value can be greater than that of distant future, or less than that of distant past.
- I am not sure if the Julian Day method is correctly implemented. I simply converted the Julian days to seconds and added them as the duration. I don't know if an additional conversion is required.

Resolves #28 
Resolves #18 