### PR TITLE
Add line load_points using a vec3 array; use environment variable for shader loading

### DIFF
--- a/src/ellipse.cpp
+++ b/src/ellipse.cpp
@@ -27,14 +27,16 @@
 
 namespace {  // anonymous namespace
 nzl::Program create_program() {
-  std::string vertSource = nzl::slurp("../shaders/simple_shader.vert");
+  const std::string vertex_shader_source =
+      nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.vert");
 
-  std::string fragSource = nzl::slurp("../shaders/simple_shader.vert");
+  const std::string fragment_shader_source =
+      nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.frag");
 
-  nzl::Shader vert_shader(nzl::Shader::Stage::Vertex, vertSource);
+  nzl::Shader vert_shader(nzl::Shader::Stage::Vertex, vertex_shader_source);
   vert_shader.compile();
 
-  nzl::Shader frag_shader(nzl::Shader::Stage::Fragment, fragSource);
+  nzl::Shader frag_shader(nzl::Shader::Stage::Fragment, fragment_shader_source);
   frag_shader.compile();
 
   std::vector<nzl::Shader> vec;

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -65,7 +65,7 @@ struct nzl::Line::LineImp {
   int number_of_points{0};
   glm::vec3 color;
 
-  void load_points(std::vector<glm::vec3>& points);
+  void load_points(glm::vec3 points[], int size);
 };
 
 nzl::Line::LineImp::LineImp() : program{make_program()} {
@@ -89,13 +89,11 @@ nzl::Line::LineImp::~LineImp() noexcept {
   glDeleteBuffers(1, &vbo_id);
 }
 
-/// @TODO What would happen if points were a very large array? (hint: why are we
-/// not passing by reference or moving; why don't I have a point array).
-void nzl::Line::LineImp::load_points(std::vector<glm::vec3>& points) {
-  number_of_points = points.size();
+void nzl::Line::LineImp::load_points(glm::vec3 points[], int size) {
+  number_of_points = size;
   glBindBuffer(GL_ARRAY_BUFFER, vbo_id);
-  glBufferData(GL_ARRAY_BUFFER, points.size() * 3 * sizeof(float),
-               points.data(), GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, size * 3 * sizeof(float), points,
+               GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
@@ -110,11 +108,15 @@ Line::Line(glm::vec3 color) : m_pimpl{std::make_shared<Line::LineImp>()} {
 Line::Line() : Line(glm::vec3(1.0f, 1.0f, 1.0f)) {}
 
 Line::Line(glm::vec3 color, std::vector<glm::vec3>& points) : Line(color) {
-  m_pimpl->load_points(points);
+  load_points(points);
 }
 
 void Line::load_points(std::vector<glm::vec3>& points) noexcept {
-  m_pimpl->load_points(points);
+  m_pimpl->load_points(points.data(), points.size());
+}
+
+void Line::load_points(glm::vec3 points[], int size) noexcept {
+  m_pimpl->load_points(points, size);
 }
 
 glm::vec3 Line::color() const noexcept { return m_pimpl->color; }

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -28,10 +28,10 @@
 namespace {  // anonymous namespace
 
 const std::string vertex_shader_source =
-    nzl::slurp("../shaders/simple_shader.vert");
+    nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.vert");
 
 const std::string fragment_shader_source =
-    nzl::slurp("../shaders/simple_shader.frag");
+    nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.frag");
 
 /// @TODO This is too ugly. Program needs a full refactoring.
 auto make_program() {

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -43,6 +43,12 @@ class Line : public Geometry {
   /// @note Affects all copies of this object.
   void load_points(std::vector<glm::vec3>& points) noexcept;
 
+  /// @brief Loads points into the line's VBO.
+  /// @param points Points to be loaded into the VBO.
+  /// @param size Size of the array.
+  /// @note Affects all copies of this object.
+  void load_points(glm::vec3 points[], int size) noexcept;
+
   /// @brief Returns the line's color.
   glm::vec3 color() const noexcept;
 

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -14,8 +14,13 @@
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <system_error>
+
+// Third Party Libraries
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
 
 namespace nzl {
 
@@ -42,6 +47,44 @@ std::string get_env_var(const std::string& key) {
     ret_val = val;
   }
   return ret_val;
+}
+
+void check_gl_errors() {
+  GLenum error_code;
+  std::ostringstream oss;
+  bool found_error{false};
+  oss << "OpenGL error found: \n";
+
+  while ((error_code = glGetError()) != GL_NO_ERROR) {
+    found_error = true;
+    switch (error_code) {
+      case GL_INVALID_ENUM:
+        oss << "INVALID_ENUM\n";
+        break;
+      case GL_INVALID_VALUE:
+        oss << "INVALID_VALUE\n";
+        break;
+      case GL_INVALID_OPERATION:
+        oss << "INVALID_OPERATION\n";
+        break;
+      case GL_STACK_OVERFLOW:
+        oss << "STACK_OVERFLOW\n";
+        break;
+      case GL_STACK_UNDERFLOW:
+        oss << "STACK_UNDERFLOW\n";
+        break;
+      case GL_OUT_OF_MEMORY:
+        oss << "OUT_OF_MEMORY\n";
+        break;
+      case GL_INVALID_FRAMEBUFFER_OPERATION:
+        oss << "INVALID_FRAMEBUFFER_OPERATION\n";
+        break;
+    }
+  }
+
+  if (found_error) {
+    throw std::runtime_error(oss.str());
+  }
 }
 
 }  // namespace nzl

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -11,6 +11,7 @@
 
 // C++ Standard Library
 #include <cerrno>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -31,6 +32,16 @@ std::string slurp(const std::string& path) {
   std::ostringstream oss;
   oss << "Cannot slurp file \"" << path << "\": ";
   throw std::system_error(errno, std::system_category(), oss.str());
+}
+
+std::string get_env_var(const std::string& key) {
+  char* val;
+  val = std::getenv(key.c_str());
+  std::string ret_val = "";
+  if (val != nullptr) {
+    ret_val = val;
+  }
+  return ret_val;
 }
 
 }  // namespace nzl

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -25,4 +25,8 @@ std::string slurp(const std::string& path);
 /// @return Contents of the environment variable.
 std::string get_env_var(const std::string& key);
 
+/// @brief Checks for OpenGL errors using glGetError().
+/// @throws std::runtime_error if an error is found.
+void check_gl_errors();
+
 }  // namespace nzl

--- a/src/utilities.hpp
+++ b/src/utilities.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 // C++ Standard Library
+#include <cstdlib>
 #include <string>
 
 namespace nzl {
@@ -18,5 +19,10 @@ namespace nzl {
 /// @return The contents of the file in a string.
 /// @throws std::system_error if the file contents cannot be read.
 std::string slurp(const std::string& path);
+
+/// @brief Returns an environment variable.
+/// @param key String used as key for the variable.
+/// @return Contents of the environment variable.
+std::string get_env_var(const std::string& key);
 
 }  // namespace nzl

--- a/src/utilities.t.cpp
+++ b/src/utilities.t.cpp
@@ -12,10 +12,19 @@
 // C++ Standard Library
 #include <cstdio>
 #include <fstream>
+#include <stdexcept>
 #include <system_error>
+
+// mxd library
+#include "mxd.hpp"
+#include "window.hpp"
 
 // Google Test Framework
 #include <gtest/gtest.h>
+
+// Third party libraries
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
 
 TEST(Utilities, SlurpingMissingFileThrowsSystemError) {
   EXPECT_THROW(nzl::slurp("missing.txt"), std::system_error);
@@ -35,6 +44,18 @@ TEST(Utilities, SlurpFile) {
 
   // Remove the temporary file.
   std::remove(path.c_str());
+}
+
+TEST(Utilities, CheckGLError) {
+  nzl::initialize();
+  nzl::Window win(800, 600, "Hidden Window");
+  win.hide();
+  win.make_current();
+
+  glBindBuffer(3000, 1);
+  EXPECT_THROW(nzl::check_gl_errors(), std::runtime_error);
+
+  nzl::terminate();
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
I have added a function to be able to load points to a line from an array instead of a vector(to address a todo) and also have switched the shader loading from an absolute path to an environment variable, which is called SHADERS_PATH. I have included further details in the commit descriptions below.