### PR TITLE
Add line error checking; rename shader folder env variable

### DIFF
--- a/src/ellipse.cpp
+++ b/src/ellipse.cpp
@@ -28,10 +28,10 @@
 namespace {  // anonymous namespace
 nzl::Program create_program() {
   const std::string vertex_shader_source =
-      nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.vert");
+      nzl::slurp(nzl::get_env_var("MXD_SHADER_ROOT") + "/simple_shader.vert");
 
   const std::string fragment_shader_source =
-      nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.frag");
+      nzl::slurp(nzl::get_env_var("MXD_SHADER_ROOT") + "/simple_shader.frag");
 
   nzl::Shader vert_shader(nzl::Shader::Stage::Vertex, vertex_shader_source);
   vert_shader.compile();

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -58,7 +58,7 @@ namespace nzl {
 /// Put all you need in the Implementation.
 struct nzl::Line::LineImp {
   LineImp();
-  ~LineImp() noexcept;
+  ~LineImp();
   nzl::Program program;  /// @TODO Why not provide a default constructor?
   unsigned int vao_id;
   unsigned int vbo_id;
@@ -69,8 +69,6 @@ struct nzl::Line::LineImp {
 };
 
 nzl::Line::LineImp::LineImp() : program{make_program()} {
-  /// @TODO Add error checking! 10 minutes spent adding good error checking and
-  /// error messages will save you 10 hours debugging the program in the future.
   glGenVertexArrays(1, &vao_id);
   glBindVertexArray(vao_id);
   glGenBuffers(1, &vbo_id);
@@ -81,12 +79,13 @@ nzl::Line::LineImp::LineImp() : program{make_program()} {
   glDisableVertexAttribArray(0);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
-}
 
-nzl::Line::LineImp::~LineImp() noexcept {
-  /// @TODO: Add error checking!
+  nzl::check_gl_errors();
+}
+nzl::Line::LineImp::~LineImp() {
   glDeleteVertexArrays(1, &vao_id);
   glDeleteBuffers(1, &vbo_id);
+  nzl::check_gl_errors();
 }
 
 void nzl::Line::LineImp::load_points(glm::vec3 points[], int size) {
@@ -95,6 +94,7 @@ void nzl::Line::LineImp::load_points(glm::vec3 points[], int size) {
   glBufferData(GL_ARRAY_BUFFER, size * 3 * sizeof(float), points,
                GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
+  nzl::check_gl_errors();
 }
 
 // -----------------------------------------------------------------------------
@@ -111,11 +111,11 @@ Line::Line(glm::vec3 color, std::vector<glm::vec3>& points) : Line(color) {
   load_points(points);
 }
 
-void Line::load_points(std::vector<glm::vec3>& points) noexcept {
+void Line::load_points(std::vector<glm::vec3>& points) {
   m_pimpl->load_points(points.data(), points.size());
 }
 
-void Line::load_points(glm::vec3 points[], int size) noexcept {
+void Line::load_points(glm::vec3 points[], int size) {
   m_pimpl->load_points(points, size);
 }
 
@@ -134,12 +134,13 @@ void Line::do_render(TimePoint t [[maybe_unused]]) {
   program.use();
   program.set("color", m_pimpl->color);
 
-  /// @TODO Add error checking!
   glBindVertexArray(m_pimpl->vao_id);
   glEnableVertexAttribArray(0);
   glDrawArrays(GL_LINE_STRIP, 0, m_pimpl->number_of_points);
   glDisableVertexAttribArray(0);
   glBindVertexArray(0);
+
+  nzl::check_gl_errors();
 }
 
 }  // namespace nzl

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -33,12 +33,7 @@ const std::string vertex_shader_source =
 const std::string fragment_shader_source =
     nzl::slurp(nzl::get_env_var("MXD_SHADER_ROOT") + "/simple_shader.frag");
 
-/// @TODO This is too ugly. Program needs a full refactoring.
 auto make_program() {
-  /// @TODO The Shader/Program interface feels very awkward. For instance: why
-  /// do I need to pass a vector of shaders? Why do I need to compile the
-  /// shaders and then compile the program? Shouldn't the program compile the
-  /// shaders if it needs to? What happens if I forget to compile the shader?
   std::vector<nzl::Shader> shaders;
   shaders.emplace_back(nzl::Shader::Stage::Vertex, vertex_shader_source);
   shaders.emplace_back(nzl::Shader::Stage::Fragment, fragment_shader_source);
@@ -59,7 +54,7 @@ namespace nzl {
 struct nzl::Line::LineImp {
   LineImp();
   ~LineImp();
-  nzl::Program program;  /// @TODO Why not provide a default constructor?
+  nzl::Program program;
   unsigned int vao_id;
   unsigned int vbo_id;
   int number_of_points{0};

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -28,10 +28,10 @@
 namespace {  // anonymous namespace
 
 const std::string vertex_shader_source =
-    nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.vert");
+    nzl::slurp(nzl::get_env_var("MXD_SHADER_ROOT") + "/simple_shader.vert");
 
 const std::string fragment_shader_source =
-    nzl::slurp(nzl::get_env_var("SHADERS_PATH") + "/simple_shader.frag");
+    nzl::slurp(nzl::get_env_var("MXD_SHADER_ROOT") + "/simple_shader.frag");
 
 /// @TODO This is too ugly. Program needs a full refactoring.
 auto make_program() {

--- a/src/line.hpp
+++ b/src/line.hpp
@@ -27,27 +27,32 @@ namespace nzl {
 class Line : public Geometry {
  public:
   /// @brief Creates line with white color.
+  /// @throws std::runtime_error if an OpenGL error is found.
   Line();
 
   /// @brief Creates line.
   /// @param color Line color.
+  /// @throws std::runtime_error if an OpenGL error is found.
   Line(glm::vec3 color);
 
   /// @brief Creates line and loads points onto line.
   /// @param color Line color.
   /// @param points Points to be loaded into the VBO.
+  /// @throws std::runtime_error if an OpenGL error is found.
   Line(glm::vec3 color, std::vector<glm::vec3>& points);
 
   /// @brief Loads points into the line's VBO.
   /// @param points Points to be loaded into the VBO.
+  /// @throws std::runtime_error if an OpenGL error is found.
   /// @note Affects all copies of this object.
-  void load_points(std::vector<glm::vec3>& points) noexcept;
+  void load_points(std::vector<glm::vec3>& points);
 
   /// @brief Loads points into the line's VBO.
   /// @param points Points to be loaded into the VBO.
   /// @param size Size of the array.
+  /// @throws std::runtime_error if an OpenGL error is found.
   /// @note Affects all copies of this object.
-  void load_points(glm::vec3 points[], int size) noexcept;
+  void load_points(glm::vec3 points[], int size);
 
   /// @brief Returns the line's color.
   glm::vec3 color() const noexcept;


### PR DESCRIPTION
I've had to remake this from #38, since I named a commit wrongly, and thus I had to force push into my master branch in order to fix it. Here are the comments that I had left until then:

Checking for OpenGL errors is now performed sporadically in the Line
class.
-The noexcept specifier was removed from various functions, which now
can throw exceptions.
-In any function where OpenGL is called, the function to check errors
from utilities is called.

I've renamed the shader folder environment variable to MXD_SHADER_ROOT, in order to avoid conflicting with environment variables which are part of other programs.